### PR TITLE
Removed Blog.LastReader property from ElasticDapper sample.

### DIFF
--- a/Samples/Dapper/DataClasses.cs
+++ b/Samples/Dapper/DataClasses.cs
@@ -11,7 +11,5 @@ namespace ElasticDapper
         public string Name { get; set; }
 
         public string Url { get; set; }
-
-        public string LastReader { get; set; }
     }
 }


### PR DESCRIPTION
This property is not needed for sample purposes.
