### PR TITLE
Use Stopwatch for all timing operations

### DIFF
--- a/Samples/ShardSqlCmd/Program.cs
+++ b/Samples/ShardSqlCmd/Program.cs
@@ -128,8 +128,6 @@ namespace ShardSqlCmd
 
                 int rowsAffected = 0;
 
-                Stopwatch sw;
-
                 using (MultiShardCommand cmd = conn.CreateCommand())
                 {
                     cmd.CommandText = commandText;
@@ -137,12 +135,12 @@ namespace ShardSqlCmd
                     cmd.CommandTimeoutPerShard = s_commandLine.QueryTimeout;
 
                     // Execute command and time with a stopwatch
-                    sw = Stopwatch.StartNew();
+                    Stopwatch stopwatch = Stopwatch.StartNew();
                     cmd.ExecutionPolicy = s_commandLine.ExecutionPolicy;
                     cmd.ExecutionOptions = s_commandLine.ExecutionOptions;
                     using (MultiShardDataReader reader = cmd.ExecuteReader(CommandBehavior.Default))
                     {
-                        sw.Stop();
+                        stopwatch.Stop();
 
                         // Get column names
                         IEnumerable<string> columnNames = GetColumnNames(reader).ToArray();
@@ -164,11 +162,11 @@ namespace ShardSqlCmd
                         // Write formatter output
                         output.AppendLine(tableFormatter.ToString());
                     }
-                }
 
-                output.AppendLine();
-                output.AppendFormat("({0} rows affected - {1:hh}:{1:mm}:{1:ss} elapsed)", rowsAffected, sw.Elapsed);
-                output.AppendLine();
+                    output.AppendLine();
+                    output.AppendFormat("({0} rows affected - {1:hh}:{1:mm}:{1:ss} elapsed)", rowsAffected, stopwatch.Elapsed);
+                    output.AppendLine();
+                }
 
                 return output.ToString();
             }

--- a/Src/ElasticScale.Client/Query/MultiShardCommand.cs
+++ b/Src/ElasticScale.Client/Query/MultiShardCommand.cs
@@ -604,7 +604,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.Query
                     _activityId = Guid.NewGuid();
                     using (var activityIdScope = new ActivityIdScope(_activityId))
                     {
-                        DateTime executionStartTime = DateTime.UtcNow;
+                        Stopwatch stopwatch = Stopwatch.StartNew();
 
                         // Setup the Cancellation manager
                         CommandCancellationManager cmdCancellationMgr = new CommandCancellationManager(
@@ -633,7 +633,9 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.Query
                             .ContinueWith<Task<MultiShardDataReader>>(
                             (t) =>
                             {
-                                string completionTrace = string.Format("Complete; Execution Time: {0}", DateTime.UtcNow - executionStartTime);
+                                stopwatch.Stop();
+
+                                string completionTrace = string.Format("Complete; Execution Time: {0}", stopwatch.Elapsed);
 
                                 switch (t.Status)
                                 {
@@ -829,7 +831,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.Query
 
             ShardLocation shard = commandTuple.Item1;
             DbCommand command = commandTuple.Item2;
-            DateTime executionStartTime = DateTime.UtcNow;
+            Stopwatch stopwatch = Stopwatch.StartNew();
 
             // Always the close connection once the reader is done
             //
@@ -889,10 +891,12 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.Query
             return commandExecutionTask.ContinueWith<Task<LabeledDbDataReader>>(
             (t) =>
             {
+                stopwatch.Stop();
+
                 string traceMsg = string.Format(
                     "Completed command execution for Shard: {0}; Execution Time: {1}; Task Status: {2}",
                     shard,
-                    DateTime.UtcNow - executionStartTime,
+                    stopwatch.Elapsed,
                     t.Status);
 
                 switch (t.Status)

--- a/Src/ElasticScale.Client/Query/MultiShardDataReader.cs
+++ b/Src/ElasticScale.Client/Query/MultiShardDataReader.cs
@@ -19,6 +19,7 @@ using System.Data;
 using System.Data.Common;
 using System.Data.SqlClient;
 using System.Data.SqlTypes;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.IO;
 using System.Runtime.Remoting;
@@ -1014,7 +1015,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.Query
             //
             WaitForReaderOrThrow();
 
-            DateTime readStartTime = DateTime.UtcNow;
+            Stopwatch stopwatch = Stopwatch.StartNew();
 
             // We can either do this call up front and repeat it in the loop (like it is written), or we can have only
             // one read call in the loop and make the loop stopping condition checking different.  I've chosen to put a
@@ -1023,9 +1024,11 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.Query
             //
             if (this.PerformReadToFillBuffer())
             {
+                stopwatch.Stop();
+
                 // We still had a valid row to fetch on the current reader, so just return true.
                 //
-                s_tracer.Verbose("MultiShardDataReader.Read.Complete; Duration: {0}; Shard: {1}", DateTime.UtcNow - readStartTime,
+                s_tracer.Verbose("MultiShardDataReader.Read.Complete; Duration: {0}; Shard: {1}", stopwatch.Elapsed,
                     GetCurrentShardLocation());
                 return true;
             }
@@ -1062,7 +1065,9 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.Query
                 //
                 if (this.PerformReadToFillBuffer())
                 {
-                    s_tracer.Verbose("MultiShardDataReader.Read.Complete; Duration: {0}; Shard: {1}", DateTime.UtcNow - readStartTime,
+                    stopwatch.Stop();
+
+                    s_tracer.Verbose("MultiShardDataReader.Read.Complete; Duration: {0}; Shard: {1}", stopwatch.Elapsed,
                         GetCurrentShardLocation());
                     return true;
                 }

--- a/Src/ElasticScale.Client/ShardManagement/Shard/PointMapping.cs
+++ b/Src/ElasticScale.Client/ShardManagement/Shard/PointMapping.cs
@@ -283,7 +283,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <param name="conn">Connection used for validation.</param>
         void IShardProvider.Validate(IStoreShardMap shardMap, SqlConnection conn)
         {
-            DateTime startTime = DateTime.UtcNow;
+            Stopwatch stopwatch = Stopwatch.StartNew();
             Tracer.TraceInfo(TraceSourceConstants.ComponentNames.PointMapping,
                 "Validate", "Start; Connection: {0};", conn.ConnectionString);
 
@@ -293,9 +293,11 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 shardMap,
                 this.StoreMapping);
 
+            stopwatch.Stop();
+
             Tracer.TraceInfo(TraceSourceConstants.ComponentNames.PointMapping,
                 "Validate", "Complete; Connection: {0}; Duration: {1}",
-                conn.ConnectionString, DateTime.UtcNow - startTime);
+                conn.ConnectionString, stopwatch.Elapsed);
         }
 
         /// <summary>
@@ -307,7 +309,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <returns>A task to await validation completion</returns>
         async Task IShardProvider.ValidateAsync(IStoreShardMap shardMap, SqlConnection conn)
         {
-            DateTime startTime = DateTime.UtcNow;
+            Stopwatch stopwatch = Stopwatch.StartNew();
             Tracer.TraceInfo(TraceSourceConstants.ComponentNames.PointMapping,
                 "ValidateAsync", "Start; Connection: {0};", conn.ConnectionString);
 
@@ -317,9 +319,11 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 shardMap,
                 this.StoreMapping);
 
+            stopwatch.Stop();
+
             Tracer.TraceInfo(TraceSourceConstants.ComponentNames.PointMapping,
                 "ValidateAsync", "Complete; Connection: {0}; Duration: {1}",
-                conn.ConnectionString, DateTime.UtcNow - startTime);
+                conn.ConnectionString, stopwatch.Elapsed);
         }
 
         /// <summary>

--- a/Src/ElasticScale.Client/ShardManagement/Shard/RangeMapping.cs
+++ b/Src/ElasticScale.Client/ShardManagement/Shard/RangeMapping.cs
@@ -317,7 +317,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <param name="conn">Connection used for validation.</param>
         void IShardProvider.Validate(IStoreShardMap shardMap, SqlConnection conn)
         {
-            DateTime startTime = DateTime.UtcNow;
+            Stopwatch stopwatch = Stopwatch.StartNew();
             Tracer.TraceInfo(TraceSourceConstants.ComponentNames.RangeMapping,
                 "Validate", "Start; Connection: {0};", conn.ConnectionString);
 
@@ -327,9 +327,11 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 shardMap,
                 this.StoreMapping);
 
+            stopwatch.Stop();
+
             Tracer.TraceInfo(TraceSourceConstants.ComponentNames.RangeMapping,
                 "Validate", "Complete; Connection: {0}; Duration: {1}",
-                conn.ConnectionString, DateTime.UtcNow - startTime);
+                conn.ConnectionString, stopwatch.Elapsed);
         }
 
         /// <summary>
@@ -341,7 +343,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <returns>A task to await validation completion</returns>
         async Task IShardProvider.ValidateAsync(IStoreShardMap shardMap, SqlConnection conn)
         {
-            DateTime startTime = DateTime.UtcNow;
+            Stopwatch stopwatch = Stopwatch.StartNew();
             Tracer.TraceInfo(TraceSourceConstants.ComponentNames.RangeMapping,
                 "ValidateAsync", "Start; Connection: {0};", conn.ConnectionString);
 
@@ -351,9 +353,11 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 shardMap,
                 this.StoreMapping);
 
+            stopwatch.Stop();
+
             Tracer.TraceInfo(TraceSourceConstants.ComponentNames.RangeMapping,
                 "ValidateAsync", "Complete; Connection: {0}; Duration: {1}",
-                conn.ConnectionString, DateTime.UtcNow - startTime);
+                conn.ConnectionString, stopwatch.Elapsed);
         }
 
         /// <summary>

--- a/Src/ElasticScale.Client/ShardManagement/Shard/Shard.cs
+++ b/Src/ElasticScale.Client/ShardManagement/Shard/Shard.cs
@@ -344,7 +344,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <param name="conn">Connection used for validation.</param>
         void IShardProvider.Validate(IStoreShardMap shardMap, SqlConnection conn)
         {
-            DateTime startTime = DateTime.UtcNow;
+            Stopwatch stopwatch = Stopwatch.StartNew();
             Tracer.TraceInfo(TraceSourceConstants.ComponentNames.Shard,
                 "Validate", "Start; Connection: {0};", conn.ConnectionString);
 
@@ -354,9 +354,11 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 shardMap,
                 this.StoreShard);
 
+            stopwatch.Stop();
+
             Tracer.TraceInfo(TraceSourceConstants.ComponentNames.Shard,
                 "Validate", "Complete; Connection: {0}; Duration: {1}",
-                conn.ConnectionString, DateTime.UtcNow - startTime);
+                conn.ConnectionString, stopwatch.Elapsed);
         }
 
         /// <summary>
@@ -368,7 +370,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <returns>A task to await validation completion</returns>
         async Task IShardProvider.ValidateAsync(IStoreShardMap shardMap, SqlConnection conn)
         {
-            DateTime startTime = DateTime.UtcNow;
+            Stopwatch stopwatch = Stopwatch.StartNew();
             Tracer.TraceInfo(TraceSourceConstants.ComponentNames.Shard,
                 "ValidateAsync", "Start; Connection: {0};", conn.ConnectionString);
 
@@ -378,9 +380,11 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 shardMap,
                 this.StoreShard);
 
+            stopwatch.Stop();
+
             Tracer.TraceInfo(TraceSourceConstants.ComponentNames.Shard,
                 "ValidateAsync", "Complete; Connection: {0}; Duration: {1}",
-                conn.ConnectionString, DateTime.UtcNow - startTime);
+                conn.ConnectionString, stopwatch.Elapsed);
         }
 
         /// <summary>

--- a/Src/ElasticScale.Client/ShardManagement/Shard/ValidationUtils.cs
+++ b/Src/ElasticScale.Client/ShardManagement/Shard/ValidationUtils.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             IStoreShardMap shardMap,
             IStoreMapping storeMapping)
         {
-            DateTime validateStartTime = DateTime.UtcNow;
+            Stopwatch stopwatch = Stopwatch.StartNew();
 
             SqlResults lsmResult = new SqlResults();
 
@@ -76,6 +76,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 lsmResult.Result = (StoreResult)resultParam.Value;
             }
 
+            stopwatch.Stop();
+
             Tracer.TraceInfo(
                 TraceSourceConstants.ComponentNames.Shard,
                 "ValidateMapping",
@@ -83,7 +85,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 storeMapping.StoreShard.Location,
                 conn.ConnectionString,
                 lsmResult.Result,
-                DateTime.UtcNow - validateStartTime);
+                stopwatch.Elapsed);
 
             if (lsmResult.Result != StoreResult.Success)
             {
@@ -133,7 +135,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             IStoreShardMap shardMap,
             IStoreMapping storeMapping)
         {
-            DateTime validateStartTime = DateTime.UtcNow;
+            Stopwatch stopwatch = Stopwatch.StartNew();
 
             SqlResults lsmResult = new SqlResults();
 
@@ -170,6 +172,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 lsmResult.Result = (StoreResult)resultParam.Value;
             }
 
+            stopwatch.Stop();
+
             Tracer.TraceInfo(
                 TraceSourceConstants.ComponentNames.Shard,
                 "ValidateMappingAsync",
@@ -177,7 +181,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 storeMapping.StoreShard.Location,
                 conn.ConnectionString,
                 lsmResult.Result,
-                DateTime.UtcNow - validateStartTime);
+                stopwatch.Elapsed);
 
             if (lsmResult.Result != StoreResult.Success)
             {
@@ -224,7 +228,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             IStoreShard shard
             )
         {
-            DateTime validateStartTime = DateTime.UtcNow;
+            Stopwatch stopwatch = Stopwatch.StartNew();
 
             SqlResults lsmResult = new SqlResults();
 
@@ -264,6 +268,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 lsmResult.Result = (StoreResult)resultParam.Value;
             }
 
+            stopwatch.Stop();
+
             Tracer.TraceInfo(
                 TraceSourceConstants.ComponentNames.Shard,
                 "ValidateShard",
@@ -271,7 +277,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 shard.Location,
                 conn.ConnectionString,
                 lsmResult.Result,
-                DateTime.UtcNow - validateStartTime);
+                stopwatch.Elapsed);
 
             if (lsmResult.Result != StoreResult.Success)
             {
@@ -311,7 +317,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             IStoreShard shard
             )
         {
-            DateTime validateStartTime = DateTime.UtcNow;
+            Stopwatch stopwatch = Stopwatch.StartNew();
 
             SqlResults lsmResult = new SqlResults();
 
@@ -348,6 +354,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 lsmResult.Result = (StoreResult)resultParam.Value;
             }
 
+            stopwatch.Stop();
+
             Tracer.TraceInfo(
                 TraceSourceConstants.ComponentNames.Shard,
                 "ValidateShardAsync",
@@ -355,7 +363,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 shard.Location,
                 conn.ConnectionString,
                 lsmResult.Result,
-                DateTime.UtcNow - validateStartTime);
+                stopwatch.Elapsed);
 
             if (lsmResult.Result != StoreResult.Success)
             {

--- a/Src/ElasticScale.Client/ShardManagement/ShardMap/ListShardMap.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMap/ListShardMap.cs
@@ -203,7 +203,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime startTime = DateTime.UtcNow;
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 string mappingKey = BitConverter.ToString(creationInfo.Key.RawValue);
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.ListShardMap,
                     "CreatePointMapping", "Start; ShardMap name: {0}; Point Mapping: {1} ",
@@ -211,9 +212,11 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
                 PointMapping<TKey> pointMapping = _lsm.Add(new PointMapping<TKey>(this.Manager, creationInfo));
 
+                stopwatch.Stop();
+
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.ListShardMap,
                     "CreatePointMapping", "Complete; ShardMap name: {0}; Point Mapping: {1}; Duration: {2}",
-                    this.Name, mappingKey, DateTime.UtcNow - startTime);
+                    this.Name, mappingKey, stopwatch.Elapsed);
 
                 return pointMapping;
             }
@@ -233,17 +236,20 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             {
                 PointMappingCreationInfo<TKey> args = new PointMappingCreationInfo<TKey>(point, shard, MappingStatus.Online);
 
-                DateTime startTime = DateTime.UtcNow;
                 string mappingKey = BitConverter.ToString(args.Key.RawValue);
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.ListShardMap,
                     "CreatePointMapping", "Start; ShardMap name: {0}; Point Mapping: {1}",
                     this.Name, mappingKey);
 
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 PointMapping<TKey> pointMapping = _lsm.Add(new PointMapping<TKey>(this.Manager, args));
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.ListShardMap,
                     "CreatePointMapping", "Complete; ShardMap name: {0}; Point Mapping: {1}; Duration: {2}",
-                    this.Name, mappingKey, DateTime.UtcNow - startTime);
+                    this.Name, mappingKey, stopwatch.Elapsed);
 
                 return pointMapping;
             }
@@ -261,17 +267,20 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime startTime = DateTime.UtcNow;
                 string mappingKey = BitConverter.ToString(mapping.Key.RawValue);
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.ListShardMap,
                     "DeletePointMapping", "Start; ShardMap name: {0}; Point Mapping: {1}",
                     this.Name, mappingKey);
 
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 _lsm.Remove(mapping);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.ListShardMap,
                     "DeletePointMapping", "Completed; ShardMap name: {0}; Point Mapping: {1}; Duration: {2}",
-                    this.Name, mappingKey, DateTime.UtcNow - startTime);
+                    this.Name, mappingKey, stopwatch.Elapsed);
             }
         }
 
@@ -284,16 +293,19 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime startTime = DateTime.UtcNow;
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.ListShardMap,
                     "LookupPointMapping", "Start; ShardMap name: {0}; Point Mapping Key Type: {1}",
                     this.Name, typeof(TKey));
 
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 PointMapping<TKey> pointMapping = _lsm.Lookup(key, false);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.ListShardMap,
                     "LookupPointMapping", "Complete; ShardMap name: {0}; Point Mapping Key Type: {1}; Duration: {2}",
-                    this.Name, typeof(TKey), DateTime.UtcNow - startTime);
+                    this.Name, typeof(TKey), stopwatch.Elapsed);
 
                 return pointMapping;
             }
@@ -309,16 +321,19 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime startTime = DateTime.UtcNow;
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.ListShardMap,
                     "TryLookupPointMapping", "Start; ShardMap name: {0}; Point Mapping Key Type: {1}",
                     this.Name, typeof(TKey));
 
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 bool result = _lsm.TryLookup(key, false, out pointMapping);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.ListShardMap,
                     "TryLookupPointMapping", "Complete; ShardMap name: {0}; Point Mapping Key Type: {1}; Duration: {2}",
-                    this.Name, typeof(TKey), DateTime.UtcNow - startTime);
+                    this.Name, typeof(TKey), stopwatch.Elapsed);
 
                 return result;
             }
@@ -338,14 +353,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     TraceSourceConstants.ComponentNames.ListShardMap,
                     "GetPointMappings", "Start;");
 
-                DateTime startTime = DateTime.UtcNow;
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 IReadOnlyList<PointMapping<TKey>> pointMappings = _lsm.GetMappingsForRange(null, null);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ListShardMap,
                     "GetPointMappings", "Complete; Duration: {0}",
-                    DateTime.UtcNow - startTime);
+                    stopwatch.Elapsed);
 
                 return pointMappings;
             }
@@ -368,15 +385,18 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     TraceSourceConstants.ComponentNames.ListShardMap,
                     "GetPointMappings", "Start; Range: {0}",
                     range);
-                DateTime startTime = DateTime.UtcNow;
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 IReadOnlyList<PointMapping<TKey>> pointMappings = _lsm.GetMappingsForRange(range, null);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ListShardMap,
                     "GetPointMappings",
                     "Complete; Range: {0}; Duration: {1}",
-                    range, DateTime.UtcNow - startTime);
+                    range, stopwatch.Elapsed);
 
                 return pointMappings;
             }
@@ -400,14 +420,17 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     TraceSourceConstants.ComponentNames.ListShardMap,
                     "GetPointMappings", "Start; Shard: {0}",
                     shard.Location);
-                DateTime startTime = DateTime.UtcNow;
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 IReadOnlyList<PointMapping<TKey>> pointMappings = _lsm.GetMappingsForRange(null, shard);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ListShardMap,
                     "GetPointMappings", "Complete; Shard: {0}; Duration: {1}",
-                    shard.Location, DateTime.UtcNow - startTime);
+                    shard.Location, stopwatch.Elapsed);
 
                 return pointMappings;
             }
@@ -434,14 +457,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     "GetPointMappings", "Start; Shard: {0}; Range: {1}",
                     shard.Location, range);
 
-                DateTime startTime = DateTime.UtcNow;
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 IReadOnlyList<PointMapping<TKey>> pointMappings = _lsm.GetMappingsForRange(range, shard);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ListShardMap,
                     "GetPointMappings", "Complete; Shard: {0}; Duration: {1}",
-                    shard.Location, DateTime.UtcNow - startTime);
+                    shard.Location, stopwatch.Elapsed);
 
                 return pointMappings;
             }
@@ -462,14 +487,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     TraceSourceConstants.ComponentNames.ListShardMap,
                     "MarkMappingOffline", "Start; ");
 
-                DateTime startTime = DateTime.UtcNow;
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 PointMapping<TKey> result = _lsm.MarkMappingOffline(mapping);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ListShardMap,
                     "MarkMappingOffline", "Complete; Duration: {0}",
-                    DateTime.UtcNow - startTime);
+                    stopwatch.Elapsed);
 
                 return result;
             }
@@ -490,14 +517,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     TraceSourceConstants.ComponentNames.ListShardMap,
                     "MarkMappingOnline", "Start; ");
 
-                DateTime startTime = DateTime.UtcNow;
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
-                PointMapping<TKey> result = _lsm.MarkMappingOnline(mapping); ;
+                PointMapping<TKey> result = _lsm.MarkMappingOnline(mapping);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ListShardMap,
                     "MarkMappingOnline", "Complete; Duration: {0}",
-                    DateTime.UtcNow - startTime);
+                    stopwatch.Elapsed);
 
                 return result;
             }
@@ -536,17 +565,20 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime startTime = DateTime.UtcNow;
                 string mappingKey = BitConverter.ToString(currentMapping.Key.RawValue);
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.ListShardMap,
                     "UpdatePointMapping", "Start; ShardMap name: {0}; Current Point Mapping: {1}",
                     this.Name, mappingKey);
 
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 PointMapping<TKey> pointMapping = _lsm.Update(currentMapping, update, mappingLockToken.LockOwnerId);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.ListShardMap,
                     "UpdatePointMapping", "Complete; ShardMap name: {0}; Current Point Mapping: {1}; Duration: {2}",
-                    this.Name, mappingKey, DateTime.UtcNow - startTime);
+                    this.Name, mappingKey, stopwatch.Elapsed);
 
                 return pointMapping;
             }
@@ -567,14 +599,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     TraceSourceConstants.ComponentNames.ListShardMap,
                     "LookupLockOwner", "Start");
 
-                DateTime startTime = DateTime.UtcNow;
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 Guid storeLockOwnerId = _lsm.GetLockOwnerForMapping(mapping);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ListShardMap,
                     "LookupLockOwner", "Complete; Duration: {0}; StoreLockOwnerId: {1}",
-                    DateTime.UtcNow - startTime, storeLockOwnerId);
+                    stopwatch.Elapsed, storeLockOwnerId);
 
                 return new MappingLockToken(storeLockOwnerId);
             }
@@ -601,14 +635,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     TraceSourceConstants.ComponentNames.ListShardMap,
                     "Lock", "Start; LockOwnerId: {0}", lockOwnerId);
 
-                DateTime startTime = DateTime.UtcNow;
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 _lsm.LockOrUnlockMappings(mapping, lockOwnerId, LockOwnerIdOpType.Lock);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ListShardMap,
                     "Lock", "Complete; Duration: {0}; StoreLockOwnerId: {1}",
-                    DateTime.UtcNow - startTime, lockOwnerId);
+                    stopwatch.Elapsed, lockOwnerId);
             }
         }
 
@@ -630,14 +666,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     TraceSourceConstants.ComponentNames.ListShardMap,
                     "Unlock", "Start; LockOwnerId: {0}", lockOwnerId);
 
-                DateTime startTime = DateTime.UtcNow;
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 _lsm.LockOrUnlockMappings(mapping, lockOwnerId, LockOwnerIdOpType.UnlockMappingForId);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ListShardMap,
                     "UnLock", "Complete; Duration: {0}; StoreLockOwnerId: {1}",
-                    DateTime.UtcNow - startTime, lockOwnerId);
+                    stopwatch.Elapsed, lockOwnerId);
             }
         }
 
@@ -657,14 +695,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     TraceSourceConstants.ComponentNames.ListShardMap,
                     "UnlockAllMappingsWithLockOwnerId", "Start; LockOwnerId: {0}", lockOwnerId);
 
-                DateTime startTime = DateTime.UtcNow;
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 _lsm.LockOrUnlockMappings(null, lockOwnerId, LockOwnerIdOpType.UnlockAllMappingsForId);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ListShardMap,
                     "UnlockAllMappingsWithLockOwnerId", "Complete; Duration: {0}",
-                    DateTime.UtcNow - startTime);
+                    stopwatch.Elapsed);
             }
         }
 

--- a/Src/ElasticScale.Client/ShardManagement/ShardMap/RangeShardMap.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMap/RangeShardMap.cs
@@ -158,13 +158,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             {
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.RangeShardMap,
                     "CreateRangeMapping", "Start; Shard: {0}", creationInfo.Shard.Location);
-                DateTime startTime = DateTime.UtcNow;
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 RangeMapping<TKey> rangeMapping = this.rsm.Add(new RangeMapping<TKey>(this.Manager, creationInfo));
 
+                stopwatch.Stop();
+
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.RangeShardMap,
                     "CreateRangeMapping", "Complete; Shard: {0}; Duration: {1}",
-                    creationInfo.Shard.Location, DateTime.UtcNow - startTime);
+                    creationInfo.Shard.Location, stopwatch.Elapsed);
 
                 return rangeMapping;
             }
@@ -187,12 +190,15 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.RangeShardMap,
                     "CreateRangeMapping", "Start; Shard: {0}", shard.Location);
-                DateTime startTime = DateTime.UtcNow;
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 RangeMapping<TKey> rangeMapping = this.rsm.Add(new RangeMapping<TKey>(this.Manager, args));
 
+                stopwatch.Stop();
+
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.RangeShardMap,
-                    "CreateRangeMapping", "Complete; Shard: {0}; Duration: {1}", shard.Location, DateTime.UtcNow - startTime);
+                    "CreateRangeMapping", "Complete; Shard: {0}; Duration: {1}", shard.Location, stopwatch.Elapsed);
 
                 return rangeMapping;
             }
@@ -226,13 +232,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             {
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.RangeShardMap,
                     "DeleteMapping", "Start; Shard: {0}", mapping.Shard.Location);
-                DateTime startTime = DateTime.UtcNow;
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 this.rsm.Remove(mapping, mappingLockToken.LockOwnerId);
 
+                stopwatch.Stop();
+
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.RangeShardMap,
                     "DeleteMapping", "Complete; Shard: {0}; Duration: {1}",
-                    mapping.Shard.Location, DateTime.UtcNow - startTime);
+                    mapping.Shard.Location, stopwatch.Elapsed);
             }
         }
 
@@ -247,13 +256,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             {
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.RangeShardMap,
                     "GetMapping", "Start; Range Mapping Key Type: {0}", typeof(TKey));
-                DateTime startTime = DateTime.UtcNow;
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 RangeMapping<TKey> rangeMapping = this.rsm.Lookup(key, false);
 
+                stopwatch.Stop();
+
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.RangeShardMap,
                     "GetMapping", "Complete; Range Mapping Key Type: {0} Duration: {1}",
-                    typeof(TKey), DateTime.UtcNow - startTime);
+                    typeof(TKey), stopwatch.Elapsed);
 
                 return rangeMapping;
             }
@@ -269,16 +281,19 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime startTime = DateTime.UtcNow;
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.RangeShardMap,
                     "TryLookupRangeMapping", "Start; ShardMap name: {0}; Range Mapping Key Type: {1}",
                     this.Name, typeof(TKey));
 
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 bool result = this.rsm.TryLookup(key, false, out rangeMapping);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.RangeShardMap,
                     "TryLookupRangeMapping", "Complete; ShardMap name: {0}; Range Mapping Key Type: {1}; Duration: {2}",
-                    this.Name, typeof(TKey), DateTime.UtcNow - startTime);
+                    this.Name, typeof(TKey), stopwatch.Elapsed);
 
                 return result;
             }
@@ -298,14 +313,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     TraceSourceConstants.ComponentNames.RangeShardMap,
                     "GetMappings", "Start;");
 
-                DateTime startTime = DateTime.UtcNow;
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 IReadOnlyList<RangeMapping<TKey>> rangeMappings = this.rsm.GetMappingsForRange(null, null);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.RangeShardMap,
                     "GetMappings", "Complete; Duration: {0}",
-                    DateTime.UtcNow - startTime);
+                    stopwatch.Elapsed);
 
                 return rangeMappings;
             }
@@ -328,15 +345,18 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     TraceSourceConstants.ComponentNames.RangeShardMap,
                     "GetMappings", "Start; Range: {0}",
                     range);
-                DateTime startTime = DateTime.UtcNow;
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 IReadOnlyList<RangeMapping<TKey>> rangeMappings = this.rsm.GetMappingsForRange(range, null);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.RangeShardMap,
                     "GetMappings",
                     "Complete; Range: {0}; Duration: {1}",
-                    range, DateTime.UtcNow - startTime);
+                    range, stopwatch.Elapsed);
 
                 return rangeMappings;
             }
@@ -361,14 +381,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     "GetMappings", "Start; Shard: {0}",
                     shard.Location);
 
-                DateTime startTime = DateTime.UtcNow;
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 IReadOnlyList<RangeMapping<TKey>> rangeMappings = this.rsm.GetMappingsForRange(null, shard);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.RangeShardMap,
                     "GetMappings", "Complete; Shard: {0}; Duration: {1}",
-                    shard.Location, DateTime.UtcNow - startTime);
+                    shard.Location, stopwatch.Elapsed);
 
                 return rangeMappings;
             }
@@ -395,14 +417,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     "GetMappings", "Start; Shard: {0}; Range: {1}",
                     shard.Location, range);
 
-                DateTime startTime = DateTime.UtcNow;
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 IReadOnlyList<RangeMapping<TKey>> rangeMappings = this.rsm.GetMappingsForRange(range, shard);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.RangeShardMap,
                     "GetMappings", "Complete; Shard: {0}; Duration: {1}",
-                    shard.Location, DateTime.UtcNow - startTime);
+                    shard.Location, stopwatch.Elapsed);
 
                 return rangeMappings;
             }
@@ -436,14 +460,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     TraceSourceConstants.ComponentNames.RangeShardMap,
                     "MarkMappingOffline", "Start; ");
 
-                DateTime startTime = DateTime.UtcNow;
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 RangeMapping<TKey> result = this.rsm.MarkMappingOffline(mapping, mappingLockToken.LockOwnerId);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.RangeShardMap,
                     "MarkMappingOffline", "Complete; Duration: {0}",
-                    DateTime.UtcNow - startTime);
+                    stopwatch.Elapsed);
 
                 return result;
             }
@@ -477,14 +503,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     TraceSourceConstants.ComponentNames.RangeShardMap,
                     "MarkMappingOnline", "Start; ");
 
-                DateTime startTime = DateTime.UtcNow;
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 RangeMapping<TKey> result = this.rsm.MarkMappingOnline(mapping, mappingLockToken.LockOwnerId);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.RangeShardMap,
                     "MarkMappingOnline", "Complete; Duration: {0}",
-                    DateTime.UtcNow - startTime);
+                    stopwatch.Elapsed);
 
                 return result;
             }
@@ -505,14 +533,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     TraceSourceConstants.ComponentNames.RangeShardMap,
                     "LookupLockOwner", "Start");
 
-                DateTime startTime = DateTime.UtcNow;
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 Guid storeLockOwnerId = this.rsm.GetLockOwnerForMapping(mapping);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.RangeShardMap,
                     "LookupLockOwner", "Complete; Duration: {0}; StoreLockOwnerId: {1}",
-                    DateTime.UtcNow - startTime, storeLockOwnerId);
+                    stopwatch.Elapsed, storeLockOwnerId);
 
                 return new MappingLockToken(storeLockOwnerId);
             }
@@ -539,14 +569,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     TraceSourceConstants.ComponentNames.RangeShardMap,
                     "Lock", "Start; LockOwnerId: {0}", lockOwnerId);
 
-                DateTime startTime = DateTime.UtcNow;
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 this.rsm.LockOrUnlockMappings(mapping, lockOwnerId, LockOwnerIdOpType.Lock);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.RangeShardMap,
                     "Lock", "Complete; Duration: {0}; StoreLockOwnerId: {1}",
-                    DateTime.UtcNow - startTime, lockOwnerId);
+                    stopwatch.Elapsed, lockOwnerId);
             }
         }
 
@@ -568,14 +600,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     TraceSourceConstants.ComponentNames.RangeShardMap,
                     "Unlock", "Start; LockOwnerId: {0}", lockOwnerId);
 
-                DateTime startTime = DateTime.UtcNow;
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 this.rsm.LockOrUnlockMappings(mapping, lockOwnerId, LockOwnerIdOpType.UnlockMappingForId);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.RangeShardMap,
                     "UnLock", "Complete; Duration: {0}; StoreLockOwnerId: {1}",
-                    DateTime.UtcNow - startTime, lockOwnerId);
+                    stopwatch.Elapsed, lockOwnerId);
             }
         }
 
@@ -595,14 +629,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     TraceSourceConstants.ComponentNames.RangeShardMap,
                     "UnlockAllMappingsWithLockOwnerId", "Start; LockOwnerId: {0}", lockOwnerId);
 
-                DateTime startTime = DateTime.UtcNow;
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 this.rsm.LockOrUnlockMappings(null, lockOwnerId, LockOwnerIdOpType.UnlockAllMappingsForId);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.RangeShardMap,
                     "UnlockAllMappingsWithLockOwnerId", "Complete; Duration: {0}",
-                    DateTime.UtcNow - startTime);
+                    stopwatch.Elapsed);
             }
         }
 
@@ -642,13 +678,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.RangeShardMap,
                     "UpdateMapping", "Start; Current mapping shard: {0}",
                     currentMapping.Shard.Location);
-                DateTime startTime = DateTime.UtcNow;
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 RangeMapping<TKey> rangeMapping = this.rsm.Update(currentMapping, update, mappingLockToken.LockOwnerId);
 
+                stopwatch.Stop();
+
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.RangeShardMap,
                     "UpdateMapping", "Complete; Current mapping shard: {0}; Duration: {1}",
-                    currentMapping.Shard.Location, DateTime.UtcNow - startTime);
+                    currentMapping.Shard.Location, stopwatch.Elapsed);
 
                 return rangeMapping;
             }
@@ -690,13 +729,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             {
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.RangeShardMap,
                     "SplitMapping", "Start; Shard: {0}", existingMapping.Shard.Location);
-                DateTime startTime = DateTime.UtcNow;
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 IReadOnlyList<RangeMapping<TKey>> rangeMapping = this.rsm.Split(existingMapping, splitAt, mappingLockToken.LockOwnerId);
 
+                stopwatch.Stop();
+
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.RangeShardMap,
                     "SplitMapping", "Complete; Shard: {0}; Duration: {1}",
-                    existingMapping.Shard.Location, DateTime.UtcNow - startTime);
+                    existingMapping.Shard.Location, stopwatch.Elapsed);
 
                 return rangeMapping;
             }
@@ -744,12 +786,15 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.RangeShardMap,
                     "SplitMapping", "Start; Left Shard: {0}; Right Shard: {1}",
                     left.Shard.Location, right.Shard.Location);
-                DateTime startTime = DateTime.UtcNow;
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 RangeMapping<TKey> rangeMapping = this.rsm.Merge(left, right, leftMappingLockToken.LockOwnerId, rightMappingLockToken.LockOwnerId);
 
+                stopwatch.Stop();
+
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.RangeShardMap,
-                    "SplitMapping", "Complete; Duration: {0}", DateTime.UtcNow - startTime);
+                    "SplitMapping", "Complete; Duration: {0}", stopwatch.Elapsed);
 
                 return rangeMapping;
             }

--- a/Src/ElasticScale.Client/ShardManagement/ShardMap/ShardMap.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMap/ShardMap.cs
@@ -279,19 +279,22 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime getShardStartTime = DateTime.UtcNow;
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMap,
                     "GetShards",
                     "Start; ");
 
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 IEnumerable<Shard> shards = _defaultMapper.GetShards();
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMap,
                     "GetShards",
                     "Complete; Duration: {0}",
-                    DateTime.UtcNow - getShardStartTime);
+                    stopwatch.Elapsed);
 
                 return shards;
             }
@@ -308,21 +311,24 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime getShardStartTime = DateTime.UtcNow;
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMap,
                     "GetShard",
                     "Start; Shard Location: {0} ",
                     location);
 
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 Shard shard = _defaultMapper.GetShardByLocation(location);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMap,
                     "GetShard",
                     "Complete; Shard Location: {0}; Duration: {1}",
                     location,
-                    DateTime.UtcNow - getShardStartTime);
+                    stopwatch.Elapsed);
 
                 if (shard == null)
                 {
@@ -350,21 +356,24 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime getShardStartTime = DateTime.UtcNow;
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMap,
                     "TryGetShard",
                     "Start; Shard Location: {0} ",
                     location);
 
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 shard = _defaultMapper.GetShardByLocation(location);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMap,
                     "TryGetShard",
                     "Complete; Shard Location: {0}; Duration: {1}",
                     location,
-                    DateTime.UtcNow - getShardStartTime);
+                    stopwatch.Elapsed);
 
                 return shard != null;
             }
@@ -382,12 +391,13 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             using (ActivityIdScope activityId = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime addShardStartTime = DateTime.UtcNow;
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMap,
                     "CreateShard",
                     "Start; Shard: {0} ",
                     shardCreationArgs.Location);
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 Shard shard = _defaultMapper.Add(
                     new Shard(
@@ -395,12 +405,14 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                         this,
                         shardCreationArgs));
 
+                stopwatch.Stop();
+
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMap,
                     "CreateShard",
                     "Complete; Shard: {0}; Duration: {1}",
                     shard.Location,
-                    DateTime.UtcNow - addShardStartTime);
+                    stopwatch.Elapsed);
 
                 return shard;
             }
@@ -417,12 +429,13 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             using (ActivityIdScope activityId = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime addShardStartTime = DateTime.UtcNow;
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMap,
                     "CreateShard",
                     "Start; Shard: {0} ",
                     location);
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 Shard shard = _defaultMapper.Add(
                     new Shard(
@@ -430,12 +443,14 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                         this,
                         new ShardCreationInfo(location)));
 
+                stopwatch.Stop();
+
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMap,
                     "CreateShard",
                     "Complete; Shard: {0}; Duration: {1}",
                     location,
-                    DateTime.UtcNow - addShardStartTime);
+                    stopwatch.Elapsed);
 
                 return shard;
             }
@@ -452,21 +467,24 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             using (ActivityIdScope activityId = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime deleteShardStartTime = DateTime.UtcNow;
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMap,
                     "DeleteShard",
                     "Start; Shard: {0} ",
                     shard.Location);
 
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 _defaultMapper.Remove(shard);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMap,
                     "DeleteShard",
                     "Complete; Shard: {0}; Duration: {1}",
                     shard.Location,
-                    DateTime.UtcNow - deleteShardStartTime);
+                    stopwatch.Elapsed);
             }
         }
 
@@ -484,21 +502,24 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime updateShardStartTime = DateTime.UtcNow;
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMap,
                     "UpdateShard",
                     "Start; Shard: {0}",
                     currentShard.Location);
 
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 Shard shard = _defaultMapper.UpdateShard(currentShard, update);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMap,
                     "UpdateShard",
                     "Complete; Shard: {0}; Duration: {1}",
                     currentShard.Location,
-                    DateTime.UtcNow - updateShardStartTime);
+                    stopwatch.Elapsed);
 
                 return shard;
             }
@@ -532,9 +553,6 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             IUserStoreConnection conn = this.Manager.StoreConnectionFactory.GetUserConnection(connectionStringFinal);
 
-            DateTime openConnStartTime = DateTime.UtcNow;
-            DateTime openConnEndTime = DateTime.UtcNow;
-
             Tracer.TraceInfo(
                 TraceSourceConstants.ComponentNames.ShardMap,
                 "OpenConnection", "Start; Shard: {0}; Options: {1}; ConnectionString: {2}",
@@ -544,9 +562,11 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             using (ConditionalDisposable<IUserStoreConnection> cd = new ConditionalDisposable<IUserStoreConnection>(conn))
             {
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 conn.Open();
 
-                openConnEndTime = DateTime.UtcNow;
+                stopwatch.Stop();
 
                 // If validation is requested.
                 if ((options & ConnectionOptions.Validate) == ConnectionOptions.Validate)
@@ -555,15 +575,15 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 }
 
                 cd.DoNotDispose = true;
-            }
 
-            Tracer.TraceInfo(
+                Tracer.TraceInfo(
                 TraceSourceConstants.ComponentNames.ShardMap,
                 "OpenConnection", "Complete; Shard: {0}; Options: {1}; Open Duration: {2}",
                 shardProvider.ShardInfo.Location,
                 options,
-                openConnEndTime - openConnStartTime);
-
+                stopwatch.Elapsed);
+            }
+            
             return conn.Connection;
         }
 
@@ -597,9 +617,6 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             IUserStoreConnection conn = this.Manager.StoreConnectionFactory.GetUserConnection(connectionStringFinal);
 
-            DateTime openConnStartTime = DateTime.UtcNow;
-            DateTime openConnEndTime = DateTime.UtcNow;
-
             Tracer.TraceInfo(
                 TraceSourceConstants.ComponentNames.ShardMap,
                 "OpenConnectionAsync", "Start; Shard: {0}; Options: {1}; ConnectionString: {2}",
@@ -609,9 +626,11 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             using (ConditionalDisposable<IUserStoreConnection> cd = new ConditionalDisposable<IUserStoreConnection>(conn))
             {
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 await conn.OpenAsync().ConfigureAwait(false);
 
-                openConnEndTime = DateTime.UtcNow;
+                stopwatch.Stop();
 
                 // If validation is requested.
                 if ((options & ConnectionOptions.Validate) == ConnectionOptions.Validate)
@@ -620,15 +639,15 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 }
 
                 cd.DoNotDispose = true;
-            }
 
-            Tracer.TraceInfo(
+                Tracer.TraceInfo(
                 TraceSourceConstants.ComponentNames.ShardMap,
                 "OpenConnectionAsync", "Complete; Shard: {0}; Options: {1}; Open Duration: {2}",
                 shardProvider.ShardInfo.Location,
                 options,
-                openConnEndTime - openConnStartTime);
-
+                stopwatch.Elapsed);
+            }
+            
             return conn.Connection;
         }
 

--- a/Src/ElasticScale.Client/ShardManagement/ShardMapManager/ShardMapManager.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMapManager/ShardMapManager.cs
@@ -168,28 +168,31 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
                 ListShardMap<TKey> listShardMap = new ListShardMap<TKey>(this, dssm);
 
-                DateTime createStartTime = DateTime.UtcNow;
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManager,
                     "CreateListShardMap",
                     "Start; ShardMap: {0}",
                     shardMapName);
 
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 this.AddShardMapToStore("CreateListShardMap", dssm);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManager,
                     "CreateListShardMap",
                     "Added ShardMap to Store; ShardMap: {0} Duration: {1}",
                     shardMapName,
-                    DateTime.UtcNow - createStartTime);
+                    stopwatch.Elapsed);
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManager,
                     "CreateListShardMap",
                     "Complete; ShardMap: {0} Duration: {1}",
                     shardMapName,
-                    DateTime.UtcNow - createStartTime);
+                    stopwatch.Elapsed);
 
                 return listShardMap;
             }
@@ -215,27 +218,30 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
                 RangeShardMap<TKey> rangeShardMap = new RangeShardMap<TKey>(this, dssm);
 
-                DateTime createStartTime = DateTime.UtcNow;
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManager,
                     "CreateRangeShardMap",
                     "Start; ShardMap: {0}",
                     shardMapName);
 
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 this.AddShardMapToStore("CreateRangeShardMap", dssm);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManager,
                     "CreateRangeShardMap", "Added ShardMap to Store; ShardMap: {0} Duration: {1}",
                 shardMapName,
-                    DateTime.UtcNow - createStartTime);
+                    stopwatch.Elapsed);
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManager,
                     "CreateRangeShardMap",
                     "Complete; ShardMap: {0} Duration: {1}",
                     shardMapName,
-                    DateTime.UtcNow - createStartTime);
+                    stopwatch.Elapsed);
 
                 return rangeShardMap;
             }
@@ -252,21 +258,24 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime deleteStartTime = DateTime.UtcNow;
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManager,
                     "DeleteShardMap",
                     "Start; ShardMap: {0}",
                     shardMap.Name);
 
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 this.RemoveShardMapFromStore(shardMap.StoreShardMap);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManager,
                     "DeleteShardMap",
                     "Complete; ShardMap: {0}; Duration: {1}",
                     shardMap.Name,
-                    DateTime.UtcNow - deleteStartTime);
+                    stopwatch.Elapsed);
             }
         }
 
@@ -279,19 +288,22 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime getStartTime = DateTime.UtcNow;
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManager,
                     "GetShardMaps",
                     "Start; ");
 
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 IEnumerable<ShardMap> result = this.GetShardMapsFromStore();
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManager,
                     "GetShardMaps",
                     "Complete; Duration: {0}",
-                    DateTime.UtcNow - getStartTime);
+                    stopwatch.Elapsed);
 
                 return result;
             }
@@ -517,19 +529,22 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime getStartTime = DateTime.UtcNow;
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManager,
                     "GetDistinctShardLocations",
                     "Start; ");
 
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 IEnumerable<ShardLocation> result = this.GetDistinctShardLocationsFromStore();
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManager,
                     "GetDistinctShardLocations",
                     "Complete; Duration: {0}",
-                    DateTime.Now - getStartTime);
+                    stopwatch.Elapsed);
 
                 return result;
             }
@@ -542,19 +557,22 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime getStartTime = DateTime.UtcNow;
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManager,
                     "UpgradeGlobalShardMapManager",
                     "Start; ");
 
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 this.UpgradeStoreGlobal(GlobalConstants.GsmVersionClient);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManager,
                     "UpgradeGlobalShardMapManager",
                     "Complete; Duration: {0}",
-                    DateTime.Now - getStartTime);
+                    stopwatch.Elapsed);
             }
         }
 
@@ -566,19 +584,22 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime getStartTime = DateTime.UtcNow;
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManager,
                     "UpgradeGlobalShardMapManager",
                     "Start; ");
 
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 this.UpgradeStoreLocal(location, GlobalConstants.LsmVersionClient);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManager,
                     "UpgradeGlobalShardMapManager",
                     "Complete; Duration: {0}",
-                    DateTime.Now - getStartTime);
+                    stopwatch.Elapsed);
             }
         }
 
@@ -628,13 +649,15 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             // Cache miss. Go to store and add entry to cache.
             if (ssm == null)
             {
-                DateTime storeLookupStartTime = DateTime.UtcNow;
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 shardMap = this.LookupShardMapByNameInStore(operationName, shardMapName);
 
+                stopwatch.Stop();
+
                 Tracer.TraceInfo(TraceSourceConstants.ComponentNames.ShardMapManager,
                     "LookupShardMapByName", "Lookup ShardMap: {0} in store complete; Duration: {1}",
-                    shardMapName, DateTime.UtcNow - storeLookupStartTime);
+                    shardMapName, stopwatch.Elapsed);
             }
             else
             {
@@ -686,19 +709,22 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime getStartTime = DateTime.UtcNow;
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManager,
                     "UpgradeGlobalShardMapManager",
                     "Start; ");
 
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 this.UpgradeStoreGlobal(targetVersion);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManager,
                     "UpgradeGlobalShardMapManager",
                     "Complete; Duration: {0}",
-                    DateTime.Now - getStartTime);
+                    stopwatch.Elapsed);
             }
         }
 
@@ -711,19 +737,22 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime getStartTime = DateTime.UtcNow;
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManager,
                     "UpgradeGlobalShardMapManager",
                     "Start; ");
 
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
                 this.UpgradeStoreLocal(location, targetVersion);
+
+                stopwatch.Stop();
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManager,
                     "UpgradeGlobalShardMapManager",
                     "Complete; Duration: {0}",
-                    DateTime.Now - getStartTime);
+                    stopwatch.Elapsed);
             }
         }
 

--- a/Src/ElasticScale.Client/ShardManagement/ShardMapManager/ShardMapManagerFactory.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMapManager/ShardMapManagerFactory.cs
@@ -236,11 +236,12 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime getStartTime = DateTime.UtcNow;
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManagerFactory,
                     "CreateSqlShardMapManager",
                     "Start; ");
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 SqlShardMapManagerCredentials credentials = new SqlShardMapManagerCredentials(connectionString);
 
@@ -271,11 +272,13 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                         op.Do();
                     }
 
+                    stopwatch.Stop();
+
                     Tracer.TraceInfo(
                         TraceSourceConstants.ComponentNames.ShardMapManagerFactory,
                         "CreateSqlShardMapManager",
                         "Complete; Duration: {0}",
-                        DateTime.UtcNow - getStartTime);
+                        stopwatch.Elapsed);
                 }
                 finally
                 {
@@ -343,11 +346,12 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime getStartTime = DateTime.UtcNow;
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManagerFactory,
                     "TryGetSqlShardMapManager",
                     "Start; ");
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 shardMapManager = ShardMapManagerFactory.GetSqlShardMapManager(
                     connectionString,
@@ -356,11 +360,13 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     null,
                     false);
 
+                stopwatch.Stop();
+
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManagerFactory,
                     "TryGetSqlShardMapManager",
                     "Complete; Duration: {0}",
-                    DateTime.UtcNow - getStartTime);
+                    stopwatch.Elapsed);
 
                 return shardMapManager != null;
             }
@@ -393,11 +399,12 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime getStartTime = DateTime.UtcNow;
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManagerFactory,
                     "TryGetSqlShardMapManager",
                     "Start; ");
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 shardMapManager = ShardMapManagerFactory.GetSqlShardMapManager(
                     connectionString,
@@ -406,11 +413,13 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     retryEventHandler,
                     false);
 
+                stopwatch.Stop();
+
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManagerFactory,
                     "TryGetSqlShardMapManager",
                     "Complete; Duration: {0}",
-                    DateTime.UtcNow - getStartTime);
+                    stopwatch.Elapsed);
 
                 return shardMapManager != null;
             }
@@ -481,11 +490,12 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                DateTime getStartTime = DateTime.UtcNow;
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManagerFactory,
                     "GetSqlShardMapManager",
                     "Start; ");
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 ShardMapManager shardMapManager = ShardMapManagerFactory.GetSqlShardMapManager(
                     connectionString,
@@ -494,13 +504,15 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     retryEventHandler,
                     true);
 
+                stopwatch.Stop();
+
                 Debug.Assert(shardMapManager != null);
 
                 Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManagerFactory,
                     "GetSqlShardMapManager",
                     "Complete; Duration: {0}",
-                    DateTime.UtcNow - getStartTime);
+                    stopwatch.Elapsed);
 
                 return shardMapManager;
             }

--- a/Src/ElasticScale.Client/ShardManagement/ShardMapper/BaseShardMapper.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMapper/BaseShardMapper.cs
@@ -485,7 +485,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             IStoreResults gsmResult;
 
-            DateTime startTime = DateTime.UtcNow;
+            Stopwatch stopwatch = Stopwatch.StartNew();
 
             using (IStoreOperationGlobal op = this.Manager.StoreOperationFactory.CreateFindMappingByKeyGlobalOperation(
                 this.Manager,
@@ -500,13 +500,15 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 gsmResult = op.Do();
             }
 
+            stopwatch.Stop();
+
             Tracer.TraceVerbose(
                 TraceSourceConstants.ComponentNames.BaseShardMapper,
                 "Lookup",
                 "Lookup key from GSM complete; Key type : {0}; Result: {1}; Duration: {2}",
                 typeof(TKey),
                 gsmResult.Result,
-                DateTime.UtcNow - startTime);
+                stopwatch.Elapsed);
 
             // If we could not locate the mapping, we return null and do nothing here.
             if (gsmResult.Result != StoreResult.MappingNotFoundForKey)
@@ -531,7 +533,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             IStoreResults gsmResult;
 
-            DateTime startTime = DateTime.UtcNow;
+            Stopwatch stopwatch = Stopwatch.StartNew();
 
             using (IStoreOperationGlobal op = this.Manager.StoreOperationFactory.CreateFindMappingByKeyGlobalOperation(
                 this.Manager,
@@ -546,13 +548,15 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 gsmResult = op.Do();
             }
 
+            stopwatch.Stop();
+
             Tracer.TraceVerbose(
                 TraceSourceConstants.ComponentNames.BaseShardMapper,
                 "LookupMappingForOpenConnectionForKey",
                 "Lookup key from GSM complete; Key type : {0}; Result: {1}; Duration: {2}",
                 sk.DataType,
                 gsmResult.Result,
-                DateTime.UtcNow - startTime);
+                stopwatch.Elapsed);
 
             // If we could not locate the mapping, we throw.
             if (gsmResult.Result == StoreResult.MappingNotFoundForKey)
@@ -586,7 +590,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             IStoreResults gsmResult;
 
-            DateTime startTime = DateTime.UtcNow;
+            Stopwatch stopwatch = Stopwatch.StartNew();
 
             using (IStoreOperationGlobal op = this.Manager.StoreOperationFactory.CreateFindMappingByKeyGlobalOperation(
                 this.Manager,
@@ -601,13 +605,15 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 gsmResult = await op.DoAsync();
             }
 
+            stopwatch.Stop();
+
             Tracer.TraceVerbose(
                 TraceSourceConstants.ComponentNames.BaseShardMapper,
                 "LookupMappingForOpenConnectionForKeyAsync",
                 "Lookup key from GSM complete; Key type : {0}; Result: {1}; Duration: {2}",
                 sk.DataType,
                 gsmResult.Result,
-                DateTime.UtcNow - startTime);
+                stopwatch.Elapsed);
 
             // If we could not locate the mapping, we throw.
             if (gsmResult.Result == StoreResult.MappingNotFoundForKey)

--- a/Src/ElasticScale.Client/ShardManagement/StoreOperations/ShardMapManagerFactory/CreateShardMapManagerGlobalOperation.cs
+++ b/Src/ElasticScale.Client/ShardManagement/StoreOperations/ShardMapManagerFactory/CreateShardMapManagerGlobalOperation.cs
@@ -63,12 +63,12 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// </returns>
         public override IStoreResults DoGlobalExecute(IStoreTransactionScope ts)
         {
-            DateTime createStartTime = DateTime.UtcNow;
-
             TraceHelper.Tracer.TraceInfo(
                 TraceSourceConstants.ComponentNames.ShardMapManagerFactory,
                 this.OperationName,
                 "Started creating Global Shard Map structures.");
+
+            Stopwatch stopwatch = Stopwatch.StartNew();
 
             IStoreResults checkResult = ts.ExecuteCommandSingle(SqlUtils.CheckIfExistsGlobalScript.Single());
 
@@ -97,11 +97,13 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             ts.ExecuteCommandBatch(SqlUtils.FilterUpgradeCommands(SqlUtils.UpgradeGlobalScript, _targetVersion));
 
+            stopwatch.Stop();
+
             TraceHelper.Tracer.TraceInfo(
                 TraceSourceConstants.ComponentNames.ShardMapManagerFactory,
                 this.OperationName,
                 "Finished creating Global Shard Map structures. Duration: {0}",
-                DateTime.UtcNow - createStartTime);
+                stopwatch.Elapsed);
 
             return new SqlResults();
         }

--- a/Src/ElasticScale.Client/ShardManagement/StoreOperations/Upgrade/UpgradeStoreGlobalOperation.cs
+++ b/Src/ElasticScale.Client/ShardManagement/StoreOperations/Upgrade/UpgradeStoreGlobalOperation.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             if (checkResult.StoreVersion.Version < _targetVersion)
             {
-                DateTime createStartTime = DateTime.UtcNow;
+                Stopwatch stopwatch = Stopwatch.StartNew();
 
                 ts.ExecuteCommandBatch(SqlUtils.FilterUpgradeCommands(SqlUtils.UpgradeGlobalScript, _targetVersion, checkResult.StoreVersion.Version));
 
@@ -73,11 +73,13 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
                 // DEVNOTE(apurvs): verify (checkResult.StoreVersion == GlobalConstants.GsmVersionClient) and throw on failure.
 
+                stopwatch.Stop();
+
                 TraceHelper.Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManagerFactory,
                     this.OperationName,
                     "Finished upgrading Global Shard Map. Duration: {0}",
-                    DateTime.UtcNow - createStartTime);
+                    stopwatch.Elapsed);
             }
             else
             {

--- a/Src/ElasticScale.Client/ShardManagement/StoreOperations/Upgrade/UpgradeStoreLocalOperation.cs
+++ b/Src/ElasticScale.Client/ShardManagement/StoreOperations/Upgrade/UpgradeStoreLocalOperation.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
@@ -58,7 +59,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 this.OperationName,
                 "Started upgrading Local Shard Map structures at location {0}", base.Location);
 
-            DateTime createStartTime = DateTime.UtcNow;
+            Stopwatch stopwatch = Stopwatch.StartNew();
 
             IStoreResults checkResult = ts.ExecuteCommandSingle(SqlUtils.CheckIfExistsLocalScript.Single());
             if (checkResult.StoreVersion == null)
@@ -78,12 +79,14 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 // Read LSM version again after upgrade.
                 checkResult = ts.ExecuteCommandSingle(SqlUtils.CheckIfExistsLocalScript.Single());
 
+                stopwatch.Stop();
+
                 TraceHelper.Tracer.TraceInfo(
                     TraceSourceConstants.ComponentNames.ShardMapManagerFactory,
                     this.OperationName,
                     "Finished upgrading store at location {0}. Duration: {1}",
                     base.Location,
-                    DateTime.UtcNow - createStartTime);
+                    stopwatch.Elapsed);
             }
             else
             {


### PR DESCRIPTION
There are many places in the code where an operation is timed by subtracting two `DateTime` values obtained from `DateTime.UtcNow`.   While this may give an answer, it's not ideal for several reasons.

- Precision of the system clock is only about 10ms.
- The OS clock can drift, and the OS often corrects for drift.
- The OS may update the clock via NTP sync.
- The user can update the clock manually.

There were also a lot of cases where the scope of the timing operation was including the time it took to trace things.  In general, the timing should start and stop around only the operation you want to measure.

Additionally, there were a few cases where `DateTime.Now` was used, which gives the *local* time, which would definitely be in error.

The best practice for timing computational activity (aka "profiling") is to use `System.Diagnostics.Stopwatch`, which uses the system's `QueryPerformanceCounter` (QPC) function instead of the clock.  (For nitty-gritty details, read [Acquiring high-resolution time stamps](https://msdn.microsoft.com/en-us/library/windows/desktop/dn553408.aspx) on MSDN).

This PR updates all invocations to use `Stopwatch` instead of `DateTime.UtcNow`.