### PR TITLE
Transient fault handing for sp_releaselock call

### DIFF
--- a/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlStoreConnection.cs
+++ b/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlStoreConnection.cs
@@ -100,7 +100,10 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             {
                 if (_conn != null)
                 {
-                    this.ReleaseAppLock(lockId);
+                    if (_conn.State == ConnectionState.Open)
+                    {
+                        this.ReleaseAppLock(lockId);
+                    }
                     _conn.Dispose();
                     _conn = null;
                 }
@@ -243,7 +246,15 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     0,
                     0);
 
-                cmdReleaseAppLock.ExecuteNonQuery();
+                try
+                {
+                    cmdReleaseAppLock.ExecuteNonQuery();
+                }
+                catch(Exception)
+                {
+                    // ignore all exceptions.
+                    return;
+                }
 
                 // If parameter validation or other errors happen.
                 if ((int)returnValue.Value < 0)


### PR DESCRIPTION
1. Call sp_releaselock only if connection state is open.
2. Ignore all exceptions thrown by sp_releaselock call. This function is
called from TeardownConnections() within finally{ } block so we are not
handling exceptions from this call in higher layers.