### PR TITLE
Updated EFMultiTenant sample with block predicates and SESSION_CONTEXT

### DIFF
--- a/Samples/EFMultiTenant/ApplySqlToShards.ps1
+++ b/Samples/EFMultiTenant/ApplySqlToShards.ps1
@@ -12,12 +12,8 @@ $sqlfile = 'EnableRLS.sql'
 $sqldir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $sqlpath = Join-Path -Path $sqldir -ChildPath $sqlfile
 $query = "SELECT ServerName, DatabaseName FROM __ShardManagement.ShardsGlobal;"
-$sqlpath
-$query
 
 $shards = Invoke-Sqlcmd -Query $query -ServerInstance $server -Database $shardmapmgr -Username $username -Password $password
-
-$shards
 
 foreach ($shard in $shards) {
     # Assume all shards have same username/password as shard map manager

--- a/Samples/EFMultiTenant/ApplySqlToShards.ps1
+++ b/Samples/EFMultiTenant/ApplySqlToShards.ps1
@@ -2,17 +2,22 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 # Params you must supply
-$server = ""
-$shardmapmgr = ""
-$username = ""
-$password = ""
-$sqlfile = "EnableRLS.sql"
+$server = '[YourSQLServerName]'
+$shardmapmgr = '[YourShardMapManagerDatabaseName]'
+$username = '[YourUserName]'
+$password = '[YourPassword]'
+$sqlfile = 'EnableRLS.sql'
 
 # Get shards and execute sqlfile
 $sqldir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $sqlpath = Join-Path -Path $sqldir -ChildPath $sqlfile
 $query = "SELECT ServerName, DatabaseName FROM __ShardManagement.ShardsGlobal;"
+$sqlpath
+$query
+
 $shards = Invoke-Sqlcmd -Query $query -ServerInstance $server -Database $shardmapmgr -Username $username -Password $password
+
+$shards
 
 foreach ($shard in $shards) {
     # Assume all shards have same username/password as shard map manager

--- a/Samples/EFMultiTenant/ElasticScaleContext.cs
+++ b/Samples/EFMultiTenant/ElasticScaleContext.cs
@@ -65,9 +65,9 @@ namespace EFMultiTenantElasticScale
             {
                 conn = shardMap.OpenConnectionForKey(shardingKey, connectionStr, ConnectionOptions.Validate);
 
-                // Set CONTEXT_INFO to shardingKey to enable Row-Level Security filtering
+                // Set TenantId in SESSION_CONTEXT to shardingKey to enable Row-Level Security filtering
                 SqlCommand cmd = conn.CreateCommand();
-                cmd.CommandText = @"SET CONTEXT_INFO @shardingKey";
+                cmd.CommandText = @"exec sp_set_session_context @key=N'TenantId', @value=@shardingKey";
                 cmd.Parameters.AddWithValue("@shardingKey", shardingKey);
                 cmd.ExecuteNonQuery();
 

--- a/Samples/EFMultiTenant/EnableRLS.sql
+++ b/Samples/EFMultiTenant/EnableRLS.sql
@@ -11,35 +11,14 @@ CREATE FUNCTION rls.fn_tenantAccessPredicate(@TenantId int)
 AS
     RETURN SELECT 1 AS fn_accessResult 
         WHERE DATABASE_PRINCIPAL_ID() = DATABASE_PRINCIPAL_ID('dbo') -- the user in your application’s connection string (dbo is only for demo purposes!)
-        AND CONVERT(int, CONVERT(varbinary(4), CONTEXT_INFO())) = @TenantId -- @TenantId (int) is 4 bytes
+		AND CAST(SESSION_CONTEXT(N'TenantId') AS int) = @TenantId
 GO
 
 CREATE SECURITY POLICY rls.tenantAccessPolicy
     ADD FILTER PREDICATE rls.fn_tenantAccessPredicate(TenantId) ON dbo.Blogs,
-    ADD FILTER PREDICATE rls.fn_tenantAccessPredicate(TenantId) ON dbo.Posts
-GO
-
--- Create a scalar version of the predicate function for use in check constraints
-CREATE FUNCTION rls.fn_tenantAccessPredicateScalar(@TenantId int)
-    RETURNS bit
-AS
-    BEGIN
-    IF EXISTS( SELECT 1 FROM rls.fn_tenantAccessPredicate(@TenantId) )
-        RETURN 1
-    RETURN 0
-END
-GO
-
--- Add the function as a check constraint on all sharded tables
-ALTER TABLE Blogs
-	WITH NOCHECK -- don't check data already in table
-	ADD CONSTRAINT chk_blocking_Blogs -- needs a unique name
-	CHECK( rls.fn_tenantAccessPredicateScalar(TenantId) = 1 )
-GO
-ALTER TABLE Posts
-	WITH NOCHECK
-	ADD CONSTRAINT chk_blocking_Posts
-	CHECK( rls.fn_tenantAccessPredicateScalar(TenantId) = 1 )
+	ADD BLOCK PREDICATE rls.fn_tenantAccessPredicate(TenantId) ON dbo.Blogs,
+    ADD FILTER PREDICATE rls.fn_tenantAccessPredicate(TenantId) ON dbo.Posts,
+	ADD BLOCK PREDICATE rls.fn_tenantAccessPredicate(TenantId) ON dbo.Posts
 GO
 
 -- Default constraint example
@@ -47,16 +26,16 @@ GO
 -- before creating default constraints to prevent EF from automatically supplying default values
 --ALTER TABLE Blogs
 --    ADD CONSTRAINT df_TenantId_Blogs 
---	DEFAULT CONVERT(int, CONVERT(varbinary(4), CONTEXT_INFO())) FOR TenantId
+--	DEFAULT CAST(SESSION_CONTEXT(N'TenantId') AS int) FOR TenantId
 --GO
 --ALTER TABLE Posts
 --    ADD CONSTRAINT df_TenantId_Posts 
---	DEFAULT CONVERT(int, CONVERT(varbinary(4), CONTEXT_INFO())) FOR TenantId
+--	DEFAULT CAST(SESSION_CONTEXT(N'TenantId') AS int) FOR TenantId
 --GO
 
 -- Example of altering the security policy to allow a "superuser" to access all rows
 -- Note: You should create a new function with the new logic, and then "swap" it out with 
--- the existing predicate on the Blogs and Posts tables
+-- the existing predicates on the Blogs and Posts tables
 --CREATE FUNCTION rls.fn_tenantAccessPredicateWithSuperUser(@TenantId int)
 --    RETURNS TABLE
 --    WITH SCHEMABINDING
@@ -65,7 +44,7 @@ GO
 --        WHERE 
 --		(
 --			DATABASE_PRINCIPAL_ID() = DATABASE_PRINCIPAL_ID('dbo') -- note, should not be dbo!
---			AND CONVERT(int, CONVERT(varbinary(4), CONTEXT_INFO())) = @TenantId
+--			AND CAST(SESSION_CONTEXT(N'TenantId') AS int) = @TenantId
 --		) 
 --		OR
 --		(
@@ -75,5 +54,7 @@ GO
 
 --ALTER SECURITY POLICY rls.tenantAccessPolicy
 --	ALTER FILTER PREDICATE rls.fn_tenantAccessPredicateWithSuperUser(TenantId) ON dbo.Blogs,
---	ALTER FILTER PREDICATE rls.fn_tenantAccessPredicateWithSuperUser(TenantId) ON dbo.Posts
+--  ALTER BLOCK PREDICATE rls.fn_tenantAccessPredicateWithSuperUser(TenantId) ON dbo.Blogs,
+--	ALTER FILTER PREDICATE rls.fn_tenantAccessPredicateWithSuperUser(TenantId) ON dbo.Posts,
+--	ALTER BLOCK PREDICATE rls.fn_tenantAccessPredicateWithSuperUser(TenantId) ON dbo.Posts
 --GO

--- a/Samples/EFMultiTenant/RemoveRLS.sql
+++ b/Samples/EFMultiTenant/RemoveRLS.sql
@@ -1,7 +1,7 @@
 ﻿-- Copyright (c) Microsoft. All rights reserved.
 -- Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
--- Remove RLS and check constraints
+-- Remove RLS policies and functions
 IF ( EXISTS(SELECT * FROM sys.security_policies WHERE name = 'tenantAccessPolicy') )
 	DROP SECURITY POLICY rls.tenantAccessPolicy
 go
@@ -10,16 +10,8 @@ IF ( EXISTS(SELECT * FROM sys.objects WHERE name = 'fn_tenantAccessPredicate') )
 	DROP FUNCTION rls.fn_tenantAccessPredicate
 go
 
-IF ( EXISTS(SELECT * FROM sys.check_constraints WHERE name = 'chk_blocking_Blogs') )
-	ALTER TABLE Blogs DROP CONSTRAINT chk_blocking_Blogs
-go
-
-IF ( EXISTS(SELECT * FROM sys.check_constraints WHERE name = 'chk_blocking_Posts') )
-	ALTER TABLE Posts DROP CONSTRAINT chk_blocking_Posts
-go
-
-IF ( EXISTS(SELECT * FROM sys.objects WHERE name = 'fn_tenantAccessPredicateScalar') )
-	DROP FUNCTION rls.fn_tenantAccessPredicateScalar
+IF ( EXISTS(SELECT * FROM sys.objects WHERE name = 'fn_tenantAccessPredicateWithSuperUser') )
+	DROP FUNCTION rls.fn_tenantAccessPredicateWithSuperUser
 go
 
 IF ( EXISTS(SELECT * FROM sys.schemas WHERE name = 'rls') )


### PR DESCRIPTION
- ElasticScaleContext.cs: OpenDDRConnection now uses SESSION_CONTEXT instead of CONTEXT_INFO
- Program.cs: last example is now about block predicates, not check constraints
- EnableRLS.sql: change predicate function and default constraints to use SESSION_CONTEXT, and add block predicates instead of check constraints
- RemoveRLS.sql: remove code for check constraints