### PR TITLE
Fix for issue #129

### DIFF
--- a/Src/ElasticScale.Client/ShardManagement/Cache/PerfCounterInstance.cs
+++ b/Src/ElasticScale.Client/ShardManagement/Cache/PerfCounterInstance.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 Tracer.TraceWarning(TraceSourceConstants.ComponentNames.PerfCounter,
                     "PerfCounterInstance..ctor",
                     "Exception caught while creating performance counter instance, no performance data will be collected. Exception: {0}",
-                    e.Message);
+                    e.ToString());
             }
         }
 


### PR DESCRIPTION
Fixing UnauthorizedAccessException thrown from PerfCounterInstance
constructor.
PerformanceCounterCategory.Exists() is throwing this exception if code
was deployed to Azure AppService (website). Ignoring all exceptions in
initialization code path and silently continuing, no perf data collected
in this case.