### PR TITLE
Async improvements

### DIFF
--- a/Src/ElasticScale.Client/Query/MultiShardDataReader.cs
+++ b/Src/ElasticScale.Client/Query/MultiShardDataReader.cs
@@ -1046,7 +1046,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.Query
             // call out here since the common case is that we will usually have a row to return so we can skip the setup
             // and iteration through the loop.
             //
-            if (await PerformReadToFillBuffer(cancellationToken).ConfigureAwait(false))
+            if (await PerformReadToFillBufferAsync(cancellationToken).ConfigureAwait(false))
             {
                 stopwatch.Stop();
 
@@ -1085,7 +1085,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.Query
                     return false;
                 }
 
-                if (await PerformReadToFillBuffer(cancellationToken).ConfigureAwait(false))
+                if (await PerformReadToFillBufferAsync(cancellationToken).ConfigureAwait(false))
                 {
                     stopwatch.Stop();
 
@@ -1966,7 +1966,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.Query
         /// An async task to perform the read; when executed the task returns true 
         /// if we read another row from the current reader, false if we hit the end.
         /// </returns>
-        private async Task<bool> PerformReadToFillBuffer(CancellationToken token)
+        private async Task<bool> PerformReadToFillBufferAsync(CancellationToken token)
         {
             // DEVNOTE: We could run this in either a try-catch or in a ContinueWith.
             // If we do any throwing, though, we want it to be on the main thread that called this function,

--- a/Src/ElasticScale.Client/Query/MultiShardDataReader.cs
+++ b/Src/ElasticScale.Client/Query/MultiShardDataReader.cs
@@ -988,7 +988,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.Query
 
                     WaitForReaderOrThrow();
 
-                    bool hasNextResult = await GetCurrentDataReader().NextResultAsync(cancellationToken);
+                    bool hasNextResult = await GetCurrentDataReader().NextResultAsync(cancellationToken).ConfigureAwait(false);
 
                     if (hasNextResult)
                     {
@@ -1046,7 +1046,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.Query
             // call out here since the common case is that we will usually have a row to return so we can skip the setup
             // and iteration through the loop.
             //
-            if (await PerformReadToFillBuffer(cancellationToken))
+            if (await PerformReadToFillBuffer(cancellationToken).ConfigureAwait(false))
             {
                 stopwatch.Stop();
 
@@ -1085,7 +1085,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.Query
                     return false;
                 }
 
-                if (await PerformReadToFillBuffer(cancellationToken))
+                if (await PerformReadToFillBuffer(cancellationToken).ConfigureAwait(false))
                 {
                     stopwatch.Stop();
 
@@ -1977,7 +1977,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.Query
             //
             try
             {
-                return await this.GetCurrentDataReader().ReadAsync(token);
+                return await this.GetCurrentDataReader().ReadAsync(token).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/Src/ElasticScale.Client/ShardManagement/Shard/PointMapping.cs
+++ b/Src/ElasticScale.Client/ShardManagement/Shard/PointMapping.cs
@@ -317,7 +317,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 conn,
                 this.Manager,
                 shardMap,
-                this.StoreMapping);
+                this.StoreMapping).ConfigureAwait(false);
 
             stopwatch.Stop();
 

--- a/Src/ElasticScale.Client/ShardManagement/Shard/RangeMapping.cs
+++ b/Src/ElasticScale.Client/ShardManagement/Shard/RangeMapping.cs
@@ -351,7 +351,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 conn,
                 this.Manager,
                 shardMap,
-                this.StoreMapping);
+                this.StoreMapping).ConfigureAwait(false);
 
             stopwatch.Stop();
 

--- a/Src/ElasticScale.Client/ShardManagement/Shard/Shard.cs
+++ b/Src/ElasticScale.Client/ShardManagement/Shard/Shard.cs
@@ -378,7 +378,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 conn,
                 this.Manager,
                 shardMap,
-                this.StoreShard);
+                this.StoreShard).ConfigureAwait(false);
 
             stopwatch.Stop();
 

--- a/Src/ElasticScale.Client/ShardManagement/Shard/ValidationUtils.cs
+++ b/Src/ElasticScale.Client/ShardManagement/Shard/ValidationUtils.cs
@@ -163,9 +163,9 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     0,
                     0);
 
-                using (SqlDataReader reader = await cmd.ExecuteReaderAsync())
+                using (SqlDataReader reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
                 {
-                    await lsmResult.FetchAsync(reader);
+                    await lsmResult.FetchAsync(reader).ConfigureAwait(false);
                 }
 
                 // Output parameter will be used to specify the outcome.
@@ -345,9 +345,9 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     0,
                     0);
 
-                using (SqlDataReader reader = await cmd.ExecuteReaderAsync())
+                using (SqlDataReader reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
                 {
-                    await lsmResult.FetchAsync(reader);
+                    await lsmResult.FetchAsync(reader).ConfigureAwait(false);
                 }
 
                 // Output parameter will be used to specify the outcome.

--- a/Src/ElasticScale.Client/ShardManagement/ShardMapper/BaseShardMapper.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMapper/BaseShardMapper.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 sm = await this.LookupMappingForOpenConnectionForKeyAsync(
                     sk,
                     CacheStoreMappingUpdatePolicy.OverwriteExisting,
-                    errorCategory);
+                    errorCategory).ConfigureAwait(false);
             }
 
             SqlConnection result;
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 result = await this.ShardMap.OpenConnectionAsync(
                     constructMapping(this.Manager, this.ShardMap, sm),
                     connectionString,
-                    options);
+                    options).ConfigureAwait(false);
 
                 csm.ResetTimeToLiveIfNecessary();
 
@@ -343,14 +343,14 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 sm = await this.LookupMappingForOpenConnectionForKeyAsync(
                     sk,
                     cacheUpdatePolicyOnEx,
-                    errorCategory);
+                    errorCategory).ConfigureAwait(false);
             }
 
             // One last attempt to open the connection after a cache refresh
             result = await this.ShardMap.OpenConnectionAsync(
                         constructMapping(this.Manager, this.ShardMap, sm),
                         connectionString,
-                        options);
+                        options).ConfigureAwait(false);
 
             // Reset TTL on successful connection.
             csm.ResetTimeToLiveIfNecessary();
@@ -606,7 +606,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 true,
                 false))
             {
-                gsmResult = await op.DoAsync();
+                gsmResult = await op.DoAsync().ConfigureAwait(false);
             }
 
             stopwatch.Stop();

--- a/Src/ElasticScale.Client/ShardManagement/ShardMapper/ListShardMapper.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMapper/ListShardMapper.cs
@@ -56,14 +56,14 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <param name="options">Options for validation operations to perform on opened connection.</param>
         /// <returns>A Task encapsulating an opened SqlConnection.</returns>
         /// <remarks>All non usage-error exceptions will be reported via the returned Task</remarks>
-        public async Task<SqlConnection> OpenConnectionForKeyAsync(TKey key, string connectionString, ConnectionOptions options = ConnectionOptions.Validate)
+        public Task<SqlConnection> OpenConnectionForKeyAsync(TKey key, string connectionString, ConnectionOptions options = ConnectionOptions.Validate)
         {
-            return await this.OpenConnectionForKeyAsync<PointMapping<TKey>, TKey>(
+            return this.OpenConnectionForKeyAsync<PointMapping<TKey>, TKey>(
                 key,
                 (smm, sm, ssm) => new PointMapping<TKey>(smm, sm, ssm),
                 ShardManagementErrorCategory.ListShardMap,
                 connectionString,
-                options).ConfigureAwait(false);
+                options);
         }
 
         /// <summary>

--- a/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlResults.cs
+++ b/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlResults.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             Func<Action, Task> ReadAsync = async (readAction) =>
             {
-                while (await reader.ReadAsync())
+                while (await reader.ReadAsync().ConfigureAwait(false))
                 {
                     readAction();
                 }
@@ -184,25 +184,25 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     switch (resultType)
                     {
                         case SqlResultType.ShardMap:
-                            await ReadAsync(() => _ssm.Add(new SqlShardMap(reader, 1)));
+                            await ReadAsync(() => _ssm.Add(new SqlShardMap(reader, 1))).ConfigureAwait(false);
                             break;
                         case SqlResultType.Shard:
-                            await ReadAsync(() => _ss.Add(new SqlShard(reader, 1)));
+                            await ReadAsync(() => _ss.Add(new SqlShard(reader, 1))).ConfigureAwait(false);
                             break;
                         case SqlResultType.ShardMapping:
-                            await ReadAsync(() => _sm.Add(new SqlMapping(reader, 1)));
+                            await ReadAsync(() => _sm.Add(new SqlMapping(reader, 1))).ConfigureAwait(false);
                             break;
                         case SqlResultType.ShardLocation:
-                            await ReadAsync(() => _sl.Add(new SqlLocation(reader, 1)));
+                            await ReadAsync(() => _sl.Add(new SqlLocation(reader, 1))).ConfigureAwait(false);
                             break;
                         case SqlResultType.SchemaInfo:
-                            await ReadAsync(() => _si.Add(new SqlSchemaInfo(reader, 1)));
+                            await ReadAsync(() => _si.Add(new SqlSchemaInfo(reader, 1))).ConfigureAwait(false);
                             break;
                         case SqlResultType.StoreVersion:
-                            await ReadAsync(() => _version = new SqlVersion(reader, 1));
+                            await ReadAsync(() => _version = new SqlVersion(reader, 1)).ConfigureAwait(false);
                             break;
                         case SqlResultType.Operation:
-                            await ReadAsync(() => _ops.Add(new SqlLogEntry(reader, 1)));
+                            await ReadAsync(() => _ops.Add(new SqlLogEntry(reader, 1))).ConfigureAwait(false);
                             break;
                         default:
                             // This code is unreachable, since the all values of the SqlResultType enum are explicitly handled above.
@@ -211,7 +211,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     }
                 }
             }
-            while (await reader.NextResultAsync());
+            while (await reader.NextResultAsync().ConfigureAwait(false));
         }
 
         /// <summary>

--- a/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlStoreConnection.cs
+++ b/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlStoreConnection.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             await SqlUtils.WithSqlExceptionHandlingAsync(async () =>
             {
-                await _conn.OpenAsync();
+                await _conn.OpenAsync().ConfigureAwait(false);
             });
         }
 

--- a/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlStoreConnection.cs
+++ b/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlStoreConnection.cs
@@ -54,11 +54,11 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// Asynchronously open the store connection.
         /// </summary>
         /// <returns>A task to await completion of the Open</returns>
-        public virtual async Task OpenAsync()
+        public virtual Task OpenAsync()
         {
-            await SqlUtils.WithSqlExceptionHandlingAsync(async () =>
+            return SqlUtils.WithSqlExceptionHandlingAsync(() =>
             {
-                await _conn.OpenAsync().ConfigureAwait(false);
+                return _conn.OpenAsync();
             });
         }
 

--- a/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlStoreTransactionScope.cs
+++ b/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlStoreTransactionScope.cs
@@ -141,9 +141,9 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
                     SqlParameter result = SqlUtils.AddCommandParameter(cmd, "@result", SqlDbType.Int, ParameterDirection.Output, 0, 0);
 
-                    using (SqlDataReader reader = await cmd.ExecuteReaderAsync())
+                    using (SqlDataReader reader = await cmd.ExecuteReaderAsync().ConfigureAwait(false))
                     {
-                        await results.FetchAsync(reader);
+                        await results.FetchAsync(reader).ConfigureAwait(false);
                     }
 
                     // Output parameter will be used to specify the outcome.
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 }
 
                 return results;
-            });
+            }).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlStoreTransactionScope.cs
+++ b/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlStoreTransactionScope.cs
@@ -124,9 +124,9 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <param name="operationName">Operation to execute.</param>
         /// <param name="operationData">Input data for operation.</param>
         /// <returns>Task encapsulating storage results object.</returns>
-        public virtual async Task<IStoreResults> ExecuteOperationAsync(string operationName, XElement operationData)
+        public virtual Task<IStoreResults> ExecuteOperationAsync(string operationName, XElement operationData)
         {
-            return await SqlUtils.WithSqlExceptionHandlingAsync<IStoreResults>(async () =>
+            return SqlUtils.WithSqlExceptionHandlingAsync<IStoreResults>(async () =>
             {
                 SqlResults results = new SqlResults();
 
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 }
 
                 return results;
-            }).ConfigureAwait(false);
+            });
         }
 
         /// <summary>

--- a/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlUserStoreConnection.cs
+++ b/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlUserStoreConnection.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <returns>Task to await completion of the Open</returns>
         public async Task OpenAsync()
         {
-            await _conn.OpenAsync();
+            await _conn.OpenAsync().ConfigureAwait(false);
         }
 
         #region IDisposable

--- a/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlUserStoreConnection.cs
+++ b/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlUserStoreConnection.cs
@@ -49,9 +49,9 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// Asynchronously opens the connection.
         /// </summary>
         /// <returns>Task to await completion of the Open</returns>
-        public async Task OpenAsync()
+        public Task OpenAsync()
         {
-            await _conn.OpenAsync().ConfigureAwait(false);
+            return _conn.OpenAsync();
         }
 
         #region IDisposable

--- a/Src/ElasticScale.Client/ShardManagement/StoreOperations/Base/StoreOperationGlobal.cs
+++ b/Src/ElasticScale.Client/ShardManagement/StoreOperations/Base/StoreOperationGlobal.cs
@@ -321,10 +321,10 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// Asynchronously establishes connection to the SMM GSM database.
         /// </summary>
         /// <returns>Task to await connection establishment</returns>
-        private async Task EstablishConnnectionAsync()
+        private Task EstablishConnnectionAsync()
         {
             _globalConnection = new SqlStoreConnection(StoreConnectionKind.Global, _credentials.ConnectionStringShardMapManager);
-            await _globalConnection.OpenAsync().ConfigureAwait(false);
+            return _globalConnection.OpenAsync();
         }
 
         /// <summary>

--- a/Src/ElasticScale.Client/ShardManagement/StoreOperations/Base/StoreOperationGlobal.cs
+++ b/Src/ElasticScale.Client/ShardManagement/StoreOperations/Base/StoreOperationGlobal.cs
@@ -143,11 +143,11 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                         try
                         {
                             // Open connection.
-                            await this.EstablishConnnectionAsync();
+                            await this.EstablishConnnectionAsync().ConfigureAwait(false);
 
                             using (IStoreTransactionScope ts = this.GetTransactionScope())
                             {
-                                r = await this.DoGlobalExecuteAsync(ts);
+                                r = await this.DoGlobalExecuteAsync(ts).ConfigureAwait(false);
 
                                 ts.Success = r.Result == StoreResult.Success;
                             }
@@ -171,14 +171,14 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                             // Close connection.
                             this.TeardownConnection();
                         }
-                    });
+                    }).ConfigureAwait(false);
 
                     // If pending operation, deserialize the pending operation and perform Undo.
                     if (result.StoreOperations.Any())
                     {
                         Debug.Assert(result.StoreOperations.Count() == 1);
 
-                        await this.UndoPendingStoreOperationsAsync(result.StoreOperations.Single());
+                        await this.UndoPendingStoreOperationsAsync(result.StoreOperations.Single()).ConfigureAwait(false);
                     }
                 }
                 while (result.StoreOperations.Any());
@@ -324,7 +324,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         private async Task EstablishConnnectionAsync()
         {
             _globalConnection = new SqlStoreConnection(StoreConnectionKind.Global, _credentials.ConnectionStringShardMapManager);
-            await _globalConnection.OpenAsync();
+            await _globalConnection.OpenAsync().ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Src/ElasticScale.Client/ShardManagement/StoreOperations/ShardMapper/FindMappingByKeyGlobalOperation.cs
+++ b/Src/ElasticScale.Client/ShardManagement/StoreOperations/ShardMapper/FindMappingByKeyGlobalOperation.cs
@@ -111,12 +111,12 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <returns>
         /// Task encapsulating results of the operation.
         /// </returns>
-        public override async Task<IStoreResults> DoGlobalExecuteAsync(IStoreTransactionScope ts)
+        public override Task<IStoreResults> DoGlobalExecuteAsync(IStoreTransactionScope ts)
         {
             // If no ranges are specified, blindly mark everything for deletion.
-            return await ts.ExecuteOperationAsync(
+            return ts.ExecuteOperationAsync(
                 StoreOperationRequestBuilder.SpFindShardMappingByKeyGlobal,
-                StoreOperationRequestBuilder.FindShardMappingByKeyGlobal(_shardMap, _key)).ConfigureAwait(false);
+                StoreOperationRequestBuilder.FindShardMappingByKeyGlobal(_shardMap, _key));
         }
 
         /// <summary>

--- a/Src/ElasticScale.Client/ShardManagement/StoreOperations/ShardMapper/FindMappingByKeyGlobalOperation.cs
+++ b/Src/ElasticScale.Client/ShardManagement/StoreOperations/ShardMapper/FindMappingByKeyGlobalOperation.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             // If no ranges are specified, blindly mark everything for deletion.
             return await ts.ExecuteOperationAsync(
                 StoreOperationRequestBuilder.SpFindShardMappingByKeyGlobal,
-                StoreOperationRequestBuilder.FindShardMappingByKeyGlobal(_shardMap, _key));
+                StoreOperationRequestBuilder.FindShardMappingByKeyGlobal(_shardMap, _key)).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Src/ElasticScale.Client/ShardManagement/Utils/SqlUtils.cs
+++ b/Src/ElasticScale.Client/ShardManagement/Utils/SqlUtils.cs
@@ -366,7 +366,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             try
             {
-                await operation();
+                await operation().ConfigureAwait(false);
             }
             catch (SqlException se)
             {
@@ -406,7 +406,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             try
             {
-                return await operation();
+                return await operation().ConfigureAwait(false);
             }
             catch (SqlException se)
             {

--- a/Src/ElasticScale.Client/ShardManagement/Utils/SqlUtils.cs
+++ b/Src/ElasticScale.Client/ShardManagement/Utils/SqlUtils.cs
@@ -360,13 +360,13 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <summary>
         /// Executes the code asynchronously with SqlException handling.
         /// </summary>
-        /// <param name="operation">Operation to execute.</param>
+        /// <param name="operationAsync">Operation to execute.</param>
         /// <returns>Task to await sql exception handling completion</returns>
-        internal static async Task WithSqlExceptionHandlingAsync(Func<Task> operation)
+        internal static async Task WithSqlExceptionHandlingAsync(Func<Task> operationAsync)
         {
             try
             {
-                await operation().ConfigureAwait(false);
+                await operationAsync().ConfigureAwait(false);
             }
             catch (SqlException se)
             {
@@ -400,13 +400,13 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// Asynchronously executes the code with SqlException handling.
         /// </summary>
         /// <typeparam name="TResult">Type of result.</typeparam>
-        /// <param name="operation">Operation to execute.</param>
+        /// <param name="operationAsync">Operation to execute.</param>
         /// <returns>Task encapsulating the result of the operation.</returns>
-        internal async static Task<TResult> WithSqlExceptionHandlingAsync<TResult>(Func<Task<TResult>> operation)
+        internal async static Task<TResult> WithSqlExceptionHandlingAsync<TResult>(Func<Task<TResult>> operationAsync)
         {
             try
             {
-                return await operation().ConfigureAwait(false);
+                return await operationAsync().ConfigureAwait(false);
             }
             catch (SqlException se)
             {


### PR DESCRIPTION
Commit 79249d594742648b912b8bbcf3fe253752ef9717:
I have updated all awaited methods, so they use `ConfigureAwait(false)`. This reduced the amount of thread switches in environments that use a context (such as ASP.NET method handlers or WinForms/WPF user interface threads). The elastic client library itself doesn't rely on context, so it's safe to use it.

Reducing the requirement to synchronize threads also reduces the chance of deadlocks. Client threads might block the thread for a while and thus preventing the asynchronous operation to complete.

Commit ea3467119d72e95b7cc7058fcb9fb69ad4ce150a:
Remove the `async` keyword from methods that return return the task. Removing async/await also removes the internal state machine which should improve performance (although hardly noticeable).

Commit 9dcf01cc56af14d8343d696117ce49d398a2f766:
Renamed a method and two parameters, so it's clear they are asynchronous.