### PR TITLE
Provide MappingOptions when taking mapping offline

### DIFF
--- a/Src/ElasticScale.Client/Microsoft.Azure.SqlDatabase.ElasticScale.Client.xml
+++ b/Src/ElasticScale.Client/Microsoft.Azure.SqlDatabase.ElasticScale.Client.xml
@@ -13421,6 +13421,14 @@
             <param name="mappingLockToken">An instance of <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.MappingLockToken"/></param>
             <returns>An offline mapping.</returns>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeShardMap`1.MarkMappingOffline(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeMapping{`0},Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.MappingOptions)">
+            <summary>
+            Marks the specified mapping offline.
+            </summary>
+            <param name="mapping">Input range mapping.</param>
+            <param name="options">Options for validation operations to perform on opened connection to affected shard.</param>
+            <returns>An offline mapping.</returns>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeShardMap`1.MarkMappingOffline(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeMapping{`0},Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.MappingLockToken,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.MappingOptions)">
             <summary>
             Marks the specified mapping offline.

--- a/Src/ElasticScale.Client/Microsoft.Azure.SqlDatabase.ElasticScale.Client.xml
+++ b/Src/ElasticScale.Client/Microsoft.Azure.SqlDatabase.ElasticScale.Client.xml
@@ -4747,7 +4747,7 @@
             <param name="lockOwnerId">Id of lock owner.</param>
             <returns>The store operation.</returns>
         </member>
-        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreOperationFactory.CreateUpdateMappingOperation(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationCode,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreShardMap,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,System.String,System.Guid)">
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreOperationFactory.CreateUpdateMappingOperation(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationCode,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreShardMap,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,System.String,System.Guid,System.Boolean)">
             <summary>
             Creates request to add shard to given shard map.
             </summary>
@@ -4758,6 +4758,7 @@
             <param name="mappingTarget">Updated mapping.</param>
             <param name="patternForKill">Pattern for kill commands.</param>
             <param name="lockOwnerId">Id of lock owner.</param>
+            <param name="killConnection">Whether to kill open connections.</param>
             <returns>The store operation.</returns>
         </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreOperationFactory.CreateReplaceMappingsOperation(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationCode,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreShardMap,System.Tuple{Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,System.Guid}[],System.Tuple{Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,System.Guid}[])">
@@ -6396,7 +6397,12 @@
             Pattern for kill commands.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UpdateMappingOperation.#ctor(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationCode,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreShardMap,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,System.String,System.Guid)">
+        <member name="F:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UpdateMappingOperation._killConnection">
+            <summary>
+            Does operation kill connection.
+            </summary>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UpdateMappingOperation.#ctor(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationCode,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreShardMap,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,System.String,System.Guid,System.Boolean)">
             <summary>
             Creates request to add shard to given shard map.
             </summary>
@@ -6407,8 +6413,9 @@
             <param name="mappingTarget">Updated mapping.</param>
             <param name="patternForKill">Pattern for kill commands.</param>
             <param name="lockOwnerId">Id of lock owner.</param>
+            <param name="killConnection">Whether to kill open connections.</param>
         </member>
-        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UpdateMappingOperation.#ctor(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager,System.Guid,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationState,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationCode,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreShardMap,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,System.String,System.Guid,System.Guid,System.Guid)">
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UpdateMappingOperation.#ctor(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager,System.Guid,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationState,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationCode,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreShardMap,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,System.String,System.Guid,System.Guid,System.Guid,System.Boolean)">
             <summary>
             Creates request to add shard to given shard map.
             </summary>
@@ -6423,6 +6430,7 @@
             <param name="lockOwnerId">Id of lock owner.</param>
             <param name="originalShardVersionRemoves">Original shard version for removes.</param>
             <param name="originalShardVersionAdds">Original shard version for adds.</param>
+            <param name="killConnection">Whether to kill open connections.</param>
         </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UpdateMappingOperation.GetStoreConnectionInfo">
             <summary>
@@ -8514,7 +8522,7 @@
             <param name="lockOwnerId">Id of lock owner.</param>
             <returns>The store operation.</returns>
         </member>
-        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationFactory.CreateUpdateMappingOperation(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationCode,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreShardMap,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,System.String,System.Guid)">
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationFactory.CreateUpdateMappingOperation(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationCode,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreShardMap,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,System.String,System.Guid,System.Boolean)">
             <summary>
             Creates request to add shard to given shard map.
             </summary>
@@ -8525,6 +8533,7 @@
             <param name="mappingTarget">Updated mapping.</param>
             <param name="patternForKill">Pattern for kill commands.</param>
             <param name="lockOwnerId">Id of lock owner.</param>
+            <param name="killConnection">Whether to kill open connections.</param>
             <returns>The store operation.</returns>
         </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationFactory.CreateReplaceMappingsOperation(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationCode,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreShardMap,System.Tuple{Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,System.Guid}[],System.Tuple{Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,System.Guid}[])">
@@ -9283,7 +9292,7 @@
             <param name="lockOwnerId">Lock owner.</param>
             <returns>Xml formatted request.</returns>
         </member>
-        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationRequestBuilder.UpdateShardMappingGlobal(System.Guid,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationCode,System.Boolean,System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreShardMap,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,System.Guid)">
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationRequestBuilder.UpdateShardMappingGlobal(System.Guid,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationCode,System.Boolean,System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreShardMap,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,System.Guid,System.Boolean)">
             <summary>
             Request to update mapping in given shard map in GSM.
             </summary>
@@ -9295,6 +9304,7 @@
             <param name="mappingSource">Shard to update.</param>
             <param name="mappingTarget">Updated shard.</param>
             <param name="lockOwnerId">Lock owner.</param>
+            <param name="killConnection">Whether to kill open connections.</param>
             <returns>Xml formatted request.</returns>
         </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationRequestBuilder.ReplaceShardMappingsGlobal(System.Guid,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationCode,System.Boolean,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreShardMap,System.Tuple{Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,System.Guid}[],System.Tuple{Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,System.Guid}[])">
@@ -9713,7 +9723,7 @@
             The Tracer
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.BaseShardMapper.SetStatus``3(``0,``2,System.Func{``2,``2},System.Func{``2,``1},System.Func{``0,``1,System.Guid,``0},System.Guid)">
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.BaseShardMapper.SetStatus``3(``0,``2,System.Func{``2,``2},System.Func{``2,``1},System.Func{``0,``1,System.Guid,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.MappingOptions,``0},System.Guid,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.MappingOptions)">
             <summary>
             Sets the status of a shardmapping
             </summary>
@@ -9729,6 +9739,7 @@
             <param name="runUpdate">Delegate to perform update from the <paramref name="mapping">input mapping</paramref> and 
             the update object returned by <paramref name="getStatus">createUpdate</paramref>.</param>
             <param name="lockOwnerId">Lock owner id of this mapping</param>
+            <param name="options">Options for validation operations to perform on opened connection to affected shard.</param>
             <returns></returns>
         </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.BaseShardMapper.OpenConnectionForKey``2(``1,System.Func{Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMap,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,``0},Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardManagementErrorCategory,System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
@@ -9824,7 +9835,7 @@
             <param name="mappingType">Name of mapping type.</param>
             <returns>Read-only collection of mappings that overlap with given range.</returns>
         </member>
-        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.BaseShardMapper.Update``3(``0,``1,System.Func{Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMap,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,``0},System.Func{``2,System.Int32},System.Func{System.Int32,``2},System.Guid)">
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.BaseShardMapper.Update``3(``0,``1,System.Func{Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMap,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,``0},System.Func{``2,System.Int32},System.Func{System.Int32,``2},System.Guid,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.MappingOptions)">
             <summary>
             Allows for update to a mapping with the updates provided in 
             the <paramref name="update"/> parameter.
@@ -9835,6 +9846,7 @@
             <param name="statusAsInt">Delegate to get the mapping status as an integer value.</param>
             <param name="intAsStatus">Delegate to get the mapping status from an integer value.</param>
             <param name="lockOwnerId">Lock owner id of this mapping</param>
+            <param name="options">Options for validation operations to perform on opened connection to affected shard.</param>
             <returns>New instance of mapping with updated information.</returns>
         </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.BaseShardMapper.GetLockOwnerForMapping``1(``0,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardManagementErrorCategory)">
@@ -9968,6 +9980,26 @@
             the mapping information was last cached at the client.
             </summary>
         </member>
+        <member name="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.MappingOptions">
+            <summary>
+            Allows users to specify operations such as validation, to perform 
+            on the affected shard in the mapping.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.MappingOptions.None">
+            <summary>
+            No operation will be performed on the affected shard.
+            </summary>
+        </member>
+        <member name="F:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.MappingOptions.Validate">
+            <summary>
+            Validation operations will be performed on affected shard.
+            When a mapping is taken offline, connections to the affected
+            shard will be killed in order to prevent inconsistent or 
+            incomplete results for queries directed against mappings 
+            being changed.
+            </summary>
+        </member>
         <member name="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IShardMapper">
             <summary>
             Container for a collection of keys to shards mappings.
@@ -10084,12 +10116,13 @@
             <returns>A Task encapsulating an opened SqlConnection.</returns>
             <remarks>All non usage-error exceptions will be reported via the returned Task</remarks>
         </member>
-        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ListShardMapper`1.MarkMappingOffline(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.PointMapping{`0},System.Guid)">
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ListShardMapper`1.MarkMappingOffline(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.PointMapping{`0},System.Guid,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.MappingOptions)">
             <summary>
             Marks the given mapping offline.
             </summary>
             <param name="mapping">Input point mapping.</param>
             <param name="lockOwnerId">Lock owner id of this mapping</param>
+            <param name="options">Options for validation operations to perform on opened connection to affected shard.</param>
             <returns>An offline mapping.</returns>
         </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ListShardMapper`1.MarkMappingOnline(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.PointMapping{`0},System.Guid)">
@@ -10139,7 +10172,7 @@
             <param name="shard">Optional shard parameter, if null, we cover all shards.</param>
             <returns>Read-only collection of mappings that overlap with given range.</returns>
         </member>
-        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ListShardMapper`1.Update(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.PointMapping{`0},Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.PointMappingUpdate,System.Guid)">
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ListShardMapper`1.Update(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.PointMapping{`0},Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.PointMappingUpdate,System.Guid,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.MappingOptions)">
             <summary>
             Allows for update to a point mapping with the updates provided in 
             the <paramref name="update"/> parameter.
@@ -10147,6 +10180,7 @@
             <param name="currentMapping">Mapping being updated.</param>
             <param name="update">Updated properties of the Shard.</param>
             <param name="lockOwnerId">Lock owner id of this mapping</param>
+            <param name="options">Options for validation operations to perform on opened connection to affected shard.</param>
             <returns>New instance of mapping with updated information.</returns>
         </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ListShardMapper`1.GetLockOwnerForMapping(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.PointMapping{`0})">
@@ -10203,12 +10237,13 @@
             <param name="options">Options for validation operations to perform on opened connection.</param>
             <returns>A Task encapsulating an opened SqlConnection.</returns>
         </member>
-        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeShardMapper`1.MarkMappingOffline(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeMapping{`0},System.Guid)">
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeShardMapper`1.MarkMappingOffline(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeMapping{`0},System.Guid,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.MappingOptions)">
             <summary>
             Marks the given mapping offline.
             </summary>
             <param name="mapping">Input range mapping.</param>
             <param name="lockOwnerId">Lock owner id of this mapping</param>
+            <param name="options">Options for validation operations to perform on opened connection to affected shard.</param>
             <returns>An offline mapping.</returns>
         </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeShardMapper`1.MarkMappingOnline(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeMapping{`0},System.Guid)">
@@ -10258,7 +10293,7 @@
             <param name="shard">Optional shard parameter, if null, we cover all shards.</param>
             <returns>Read-only collection of mappings that overlap with given range.</returns>
         </member>
-        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeShardMapper`1.Update(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeMapping{`0},Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeMappingUpdate,System.Guid)">
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeShardMapper`1.Update(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeMapping{`0},Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeMappingUpdate,System.Guid,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.MappingOptions)">
             <summary>
             Allows for update to a range mapping with the updates provided in 
             the <paramref name="update"/> parameter.
@@ -10266,6 +10301,7 @@
             <param name="currentMapping">Mapping being updated.</param>
             <param name="update">Updated properties of the Shard.</param>
             <param name="lockOwnerId">Lock owner id of this mapping</param>
+            <param name="options">Options for validation operations to perform on opened connection to affected shard.</param>
             <returns>New instance of mapping with updated information.</returns>
         </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeShardMapper`1.Split(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeMapping{`0},`0,System.Guid)">
@@ -13113,6 +13149,14 @@
             <param name="mapping">Input point mapping.</param>
             <returns>An offline mapping.</returns>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ListShardMap`1.MarkMappingOffline(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.PointMapping{`0},Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.MappingOptions)">
+            <summary>
+            Marks the specified mapping offline.
+            </summary>
+            <param name="mapping">Input point mapping.</param>
+            <param name="options">Options for validation operations to perform on opened connection to affected shard.</param>
+            <returns>An offline mapping.</returns>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ListShardMap`1.MarkMappingOnline(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.PointMapping{`0})">
             <summary>
             Marks the specified mapping online.
@@ -13375,6 +13419,15 @@
             </summary>
             <param name="mapping">Input range mapping.</param>
             <param name="mappingLockToken">An instance of <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.MappingLockToken"/></param>
+            <returns>An offline mapping.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeShardMap`1.MarkMappingOffline(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeMapping{`0},Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.MappingLockToken,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.MappingOptions)">
+            <summary>
+            Marks the specified mapping offline.
+            </summary>
+            <param name="mapping">Input range mapping.</param>
+            <param name="mappingLockToken">An instance of <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.MappingLockToken"/></param>
+            <param name="options">Options for validation operations to perform on opened connection to affected shard.</param>
             <returns>An offline mapping.</returns>
         </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeShardMap`1.MarkMappingOnline(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeMapping{`0})">

--- a/Src/ElasticScale.Client/ShardManagement/ShardMap/ListShardMap.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMap/ListShardMap.cs
@@ -479,6 +479,17 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <returns>An offline mapping.</returns>
         public PointMapping<TKey> MarkMappingOffline(PointMapping<TKey> mapping)
         {
+            return MarkMappingOffline(mapping, MappingOptions.Validate);
+
+        }
+        /// <summary>
+        /// Marks the specified mapping offline.
+        /// </summary>
+        /// <param name="mapping">Input point mapping.</param>
+        /// <param name="options">Options for validation operations to perform on opened connection to affected shard.</param>
+        /// <returns>An offline mapping.</returns>
+        public PointMapping<TKey> MarkMappingOffline(PointMapping<TKey> mapping, MappingOptions options)
+        {
             ExceptionUtils.DisallowNullArgument(mapping, "mapping");
 
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
@@ -489,7 +500,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
                 Stopwatch stopwatch = Stopwatch.StartNew();
 
-                PointMapping<TKey> result = _lsm.MarkMappingOffline(mapping);
+                PointMapping<TKey> result = _lsm.MarkMappingOffline(mapping, options : options);
 
                 stopwatch.Stop();
 

--- a/Src/ElasticScale.Client/ShardManagement/ShardMap/ListShardMap.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMap/ListShardMap.cs
@@ -480,8 +480,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         public PointMapping<TKey> MarkMappingOffline(PointMapping<TKey> mapping)
         {
             return MarkMappingOffline(mapping, MappingOptions.Validate);
-
         }
+
         /// <summary>
         /// Marks the specified mapping offline.
         /// </summary>

--- a/Src/ElasticScale.Client/ShardManagement/ShardMap/RangeShardMap.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMap/RangeShardMap.cs
@@ -457,6 +457,17 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// Marks the specified mapping offline.
         /// </summary>
         /// <param name="mapping">Input range mapping.</param>
+        /// <param name="options">Options for validation operations to perform on opened connection to affected shard.</param>
+        /// <returns>An offline mapping.</returns>
+        public RangeMapping<TKey> MarkMappingOffline(RangeMapping<TKey> mapping, MappingOptions options)
+        {
+            return this.MarkMappingOffline(mapping, MappingLockToken.NoLock, options);
+        }
+
+        /// <summary>
+        /// Marks the specified mapping offline.
+        /// </summary>
+        /// <param name="mapping">Input range mapping.</param>
         /// <param name="mappingLockToken">An instance of <see cref="MappingLockToken"/></param>
         /// <param name="options">Options for validation operations to perform on opened connection to affected shard.</param>
         /// <returns>An offline mapping.</returns>

--- a/Src/ElasticScale.Client/ShardManagement/ShardMap/RangeShardMap.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMap/RangeShardMap.cs
@@ -453,7 +453,6 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             return this.MarkMappingOffline(mapping, mappingLockToken, MappingOptions.Validate);
         }
 
-
         /// <summary>
         /// Marks the specified mapping offline.
         /// </summary>

--- a/Src/ElasticScale.Client/ShardManagement/ShardMap/RangeShardMap.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMap/RangeShardMap.cs
@@ -448,8 +448,21 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <param name="mapping">Input range mapping.</param>
         /// <param name="mappingLockToken">An instance of <see cref="MappingLockToken"/></param>
         /// <returns>An offline mapping.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "1")]
         public RangeMapping<TKey> MarkMappingOffline(RangeMapping<TKey> mapping, MappingLockToken mappingLockToken)
+        {
+            return this.MarkMappingOffline(mapping, mappingLockToken, MappingOptions.Validate);
+        }
+
+
+        /// <summary>
+        /// Marks the specified mapping offline.
+        /// </summary>
+        /// <param name="mapping">Input range mapping.</param>
+        /// <param name="mappingLockToken">An instance of <see cref="MappingLockToken"/></param>
+        /// <param name="options">Options for validation operations to perform on opened connection to affected shard.</param>
+        /// <returns>An offline mapping.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "1")]
+        public RangeMapping<TKey> MarkMappingOffline(RangeMapping<TKey> mapping, MappingLockToken mappingLockToken, MappingOptions options)
         {
             ExceptionUtils.DisallowNullArgument(mapping, "mapping");
             ExceptionUtils.DisallowNullArgument(mappingLockToken, "mappingLockToken");
@@ -462,7 +475,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
                 Stopwatch stopwatch = Stopwatch.StartNew();
 
-                RangeMapping<TKey> result = this.rsm.MarkMappingOffline(mapping, mappingLockToken.LockOwnerId);
+                RangeMapping<TKey> result = this.rsm.MarkMappingOffline(mapping, mappingLockToken.LockOwnerId, options);
 
                 stopwatch.Stop();
 
@@ -681,7 +694,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
                 Stopwatch stopwatch = Stopwatch.StartNew();
 
-                RangeMapping<TKey> rangeMapping = this.rsm.Update(currentMapping, update, mappingLockToken.LockOwnerId);
+                RangeMapping<TKey> rangeMapping = this.rsm.Update(currentMapping, update, mappingLockToken.LockOwnerId, MappingOptions.Validate);
 
                 stopwatch.Stop();
 

--- a/Src/ElasticScale.Client/ShardManagement/ShardMapper/IShardMapper.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMapper/IShardMapper.cs
@@ -28,6 +28,27 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
     }
 
     /// <summary>
+    /// Allows users to specify operations such as validation, to perform 
+    /// on the affected shard in the mapping.
+    /// </summary>
+    [Flags]
+    public enum MappingOptions
+    {
+        /// <summary>
+        /// No operation will be performed on the affected shard.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Validation operations will be performed on affected shard.
+        /// When a mapping is taken offline, connections to the affected
+        /// shard will be killed in order to prevent inconsistent or 
+        /// incomplete results for queries directed against mappings 
+        /// being changed.
+        /// </summary>
+        Validate
+    }
+    /// <summary>
     /// Container for a collection of keys to shards mappings.
     /// </summary>
     internal interface IShardMapper

--- a/Src/ElasticScale.Client/ShardManagement/ShardMapper/ListShardMapper.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMapper/ListShardMapper.cs
@@ -71,8 +71,9 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// </summary>
         /// <param name="mapping">Input point mapping.</param>
         /// <param name="lockOwnerId">Lock owner id of this mapping</param>
+        /// <param name="options">Options for validation operations to perform on opened connection to affected shard.</param>
         /// <returns>An offline mapping.</returns>
-        public PointMapping<TKey> MarkMappingOffline(PointMapping<TKey> mapping, Guid lockOwnerId = default(Guid))
+        public PointMapping<TKey> MarkMappingOffline(PointMapping<TKey> mapping, Guid lockOwnerId = default(Guid), MappingOptions options = MappingOptions.Validate)
         {
             return BaseShardMapper.SetStatus<PointMapping<TKey>, PointMappingUpdate, MappingStatus>(
                 mapping,
@@ -80,7 +81,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 s => MappingStatus.Offline,
                 s => new PointMappingUpdate() { Status = s },
                 this.Update,
-                lockOwnerId);
+                lockOwnerId,
+                options);
         }
 
         /// <summary>
@@ -196,8 +198,9 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <param name="currentMapping">Mapping being updated.</param>
         /// <param name="update">Updated properties of the Shard.</param>
         /// <param name="lockOwnerId">Lock owner id of this mapping</param>
+        /// <param name="options">Options for validation operations to perform on opened connection to affected shard.</param>
         /// <returns>New instance of mapping with updated information.</returns>
-        internal PointMapping<TKey> Update(PointMapping<TKey> currentMapping, PointMappingUpdate update, Guid lockOwnerId = default(Guid))
+        internal PointMapping<TKey> Update(PointMapping<TKey> currentMapping, PointMappingUpdate update, Guid lockOwnerId = default(Guid), MappingOptions options = MappingOptions.Validate)
         {
             return this.Update<PointMapping<TKey>, PointMappingUpdate, MappingStatus>(
                 currentMapping,
@@ -205,7 +208,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 (smm, sm, ssm) => new PointMapping<TKey>(smm, sm, ssm),
                 pms => (int)pms,
                 i => (MappingStatus)i,
-                lockOwnerId);
+                lockOwnerId,
+                options);
         }
 
         /// <summary>

--- a/Src/ElasticScale.Client/ShardManagement/ShardMapper/RangeShardMapper.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMapper/RangeShardMapper.cs
@@ -78,8 +78,9 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// </summary>
         /// <param name="mapping">Input range mapping.</param>
         /// <param name="lockOwnerId">Lock owner id of this mapping</param>
+        /// <param name="options">Options for validation operations to perform on opened connection to affected shard.</param>
         /// <returns>An offline mapping.</returns>
-        public RangeMapping<TKey> MarkMappingOffline(RangeMapping<TKey> mapping, Guid lockOwnerId)
+        public RangeMapping<TKey> MarkMappingOffline(RangeMapping<TKey> mapping, Guid lockOwnerId, MappingOptions options)
         {
             return BaseShardMapper.SetStatus<RangeMapping<TKey>, RangeMappingUpdate, MappingStatus>(
                 mapping,
@@ -87,7 +88,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 s => MappingStatus.Offline,
                 s => new RangeMappingUpdate() { Status = s },
                 this.Update,
-                lockOwnerId);
+                lockOwnerId,
+                options);
         }
 
         /// <summary>
@@ -203,8 +205,9 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <param name="currentMapping">Mapping being updated.</param>
         /// <param name="update">Updated properties of the Shard.</param>
         /// <param name="lockOwnerId">Lock owner id of this mapping</param>
+        /// <param name="options">Options for validation operations to perform on opened connection to affected shard.</param>
         /// <returns>New instance of mapping with updated information.</returns>
-        internal RangeMapping<TKey> Update(RangeMapping<TKey> currentMapping, RangeMappingUpdate update, Guid lockOwnerId)
+        internal RangeMapping<TKey> Update(RangeMapping<TKey> currentMapping, RangeMappingUpdate update, Guid lockOwnerId, MappingOptions options)
         {
             return this.Update<RangeMapping<TKey>, RangeMappingUpdate, MappingStatus>(
                 currentMapping,
@@ -212,7 +215,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 (smm, sm, ssm) => new RangeMapping<TKey>(smm, sm, ssm),
                 rms => (int)rms,
                 i => (MappingStatus)i,
-                lockOwnerId);
+                lockOwnerId,
+                options);
         }
 
         /// <summary>

--- a/Src/ElasticScale.Client/ShardManagement/StoreOperations/Base/IStoreOperationFactory.cs
+++ b/Src/ElasticScale.Client/ShardManagement/StoreOperations/Base/IStoreOperationFactory.cs
@@ -492,6 +492,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <param name="mappingTarget">Updated mapping.</param>
         /// <param name="patternForKill">Pattern for kill commands.</param>
         /// <param name="lockOwnerId">Id of lock owner.</param>
+        /// <param name="killConnection">Whether to kill open connections.</param>
         /// <returns>The store operation.</returns>
         IStoreOperation CreateUpdateMappingOperation(
             ShardMapManager shardMapManager,
@@ -500,7 +501,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             IStoreMapping mappingSource,
             IStoreMapping mappingTarget,
             string patternForKill,
-            Guid lockOwnerId);
+            Guid lockOwnerId,
+            bool killConnection);
 
         /// <summary>
         /// Creates request to replace mappings within shard map.

--- a/Src/ElasticScale.Client/ShardManagement/StoreOperations/Base/StoreOperationFactory.cs
+++ b/Src/ElasticScale.Client/ShardManagement/StoreOperations/Base/StoreOperationFactory.cs
@@ -720,6 +720,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <param name="mappingTarget">Updated mapping.</param>
         /// <param name="patternForKill">Pattern for kill commands.</param>
         /// <param name="lockOwnerId">Id of lock owner.</param>
+        /// <param name="killConnection">Whether to kill open connections.</param>
         /// <returns>The store operation.</returns>
         public virtual IStoreOperation CreateUpdateMappingOperation(
             ShardMapManager shardMapManager,
@@ -728,7 +729,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             IStoreMapping mappingSource,
             IStoreMapping mappingTarget,
             string patternForKill,
-            Guid lockOwnerId)
+            Guid lockOwnerId,
+            bool killConnection)
         {
             return new UpdateMappingOperation(
                 shardMapManager,
@@ -737,7 +739,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 mappingSource,
                 mappingTarget,
                 patternForKill,
-                lockOwnerId);
+                lockOwnerId,
+                killConnection);
         }
 
         /// <summary>
@@ -1018,7 +1021,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 root.Element("PatternForKill").Value,
                 StoreObjectFormatterXml.ReadLock(root.Element("Steps").Element("Step").Element("Lock")),
                 originalShardVersionRemoves,
-                originalShardVersionAdds);
+                originalShardVersionAdds,
+                Boolean.Parse(root.Element("KillConnection").Value));
         }
 
         /// <summary>

--- a/Src/ElasticScale.Client/ShardManagement/StoreOperations/Base/StoreOperationRequestBuilder.cs
+++ b/Src/ElasticScale.Client/ShardManagement/StoreOperations/Base/StoreOperationRequestBuilder.cs
@@ -573,6 +573,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <param name="mappingSource">Shard to update.</param>
         /// <param name="mappingTarget">Updated shard.</param>
         /// <param name="lockOwnerId">Lock owner.</param>
+        /// <param name="killConnection">Whether to kill open connections.</param>
         /// <returns>Xml formatted request.</returns>
         internal static XElement UpdateShardMappingGlobal(
             Guid operationId,
@@ -582,7 +583,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             IStoreShardMap shardMap,
             IStoreMapping mappingSource,
             IStoreMapping mappingTarget,
-            Guid lockOwnerId)
+            Guid lockOwnerId,
+            bool killConnection)
         {
             return new XElement(
                 "BulkOperationShardMappingsGlobal",
@@ -592,6 +594,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 StoreOperationRequestBuilder.StepsCount(1),
                 StoreOperationRequestBuilder.s_gsmVersion,
                 new XElement("PatternForKill", patternForKill),
+                new XElement("KillConnection", killConnection),
                 StoreObjectFormatterXml.WriteIStoreShardMap("ShardMap", shardMap),
                 new XElement("Removes",
                     StoreObjectFormatterXml.WriteIStoreShard("Shard", mappingSource.StoreShard)),

--- a/Src/ElasticScale.Client/ShardManagement/StoreOperations/ShardMapper/UpdateMappingOperation.cs
+++ b/Src/ElasticScale.Client/ShardManagement/StoreOperations/ShardMapper/UpdateMappingOperation.cs
@@ -54,6 +54,11 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         private string _patternForKill;
 
         /// <summary>
+        /// Does operation kill connection.
+        /// </summary>
+        private bool _killConnection;
+
+        /// <summary>
         /// Creates request to add shard to given shard map.
         /// </summary>
         /// <param name="shardMapManager">Shard map manager object.</param>
@@ -63,6 +68,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <param name="mappingTarget">Updated mapping.</param>
         /// <param name="patternForKill">Pattern for kill commands.</param>
         /// <param name="lockOwnerId">Id of lock owner.</param>
+        /// <param name="killConnection">Whether to kill open connections.</param>
         protected internal UpdateMappingOperation(
             ShardMapManager shardMapManager,
             StoreOperationCode operationCode,
@@ -70,7 +76,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             IStoreMapping mappingSource,
             IStoreMapping mappingTarget,
             string patternForKill,
-            Guid lockOwnerId) :
+            Guid lockOwnerId,
+            bool killConnection) :
             this(
             shardMapManager,
             Guid.NewGuid(),
@@ -82,7 +89,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             patternForKill,
             lockOwnerId,
             default(Guid),
-            default(Guid))
+            default(Guid),
+            killConnection)
         {
         }
 
@@ -100,6 +108,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <param name="lockOwnerId">Id of lock owner.</param>
         /// <param name="originalShardVersionRemoves">Original shard version for removes.</param>
         /// <param name="originalShardVersionAdds">Original shard version for adds.</param>
+        /// <param name="killConnection">Whether to kill open connections.</param>
         internal UpdateMappingOperation(
             ShardMapManager shardMapManager,
             Guid operationId,
@@ -111,7 +120,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             string patternForKill,
             Guid lockOwnerId,
             Guid originalShardVersionRemoves,
-            Guid originalShardVersionAdds) :
+            Guid originalShardVersionAdds,
+            bool killConnection) :
             base(
             shardMapManager,
             operationId,
@@ -136,6 +146,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                                        operationCode == StoreOperationCode.UpdateRangeMappingWithOffline;
 
             _patternForKill = patternForKill;
+
+            _killConnection = killConnection;
         }
 
         /// <summary>
@@ -169,7 +181,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     _shardMap,
                     _mappingSource,
                     _mappingTarget,
-                    _lockOwnerId));
+                    _lockOwnerId,
+                    _killConnection));
         }
 
         /// <summary>
@@ -243,7 +256,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             // We need to treat the kill connection operation separately, the reason
             // being that we cannot perform kill operations within a transaction.
-            if (result.Result == StoreResult.Success && _fromOnlineToOffline)
+            if (result.Result == StoreResult.Success && _fromOnlineToOffline && _killConnection)
             {
                 this.KillConnectionsOnSourceShard();
             }
@@ -318,7 +331,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     _shardMap,
                     _mappingSource,
                     _mappingTarget,
-                    _lockOwnerId));
+                    _lockOwnerId,
+                    _killConnection));
         }
 
         /// <summary>
@@ -496,7 +510,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     _shardMap,
                     _mappingSource,
                     _mappingTarget,
-                    _lockOwnerId));
+                    _lockOwnerId,
+                    _killConnection));
         }
 
         /// <summary>

--- a/Test/ElasticScale.ShardManagement.UnitTests/ElasticScale.ShardManagement.UnitTests.csproj
+++ b/Test/ElasticScale.ShardManagement.UnitTests/ElasticScale.ShardManagement.UnitTests.csproj
@@ -43,6 +43,7 @@
     <Reference Include="$(NugetPack)\EnterpriseLibrary.TransientFaultHandling.Data.6.0.1304.1\lib\net45\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data.dll">
       <Name>Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data</Name>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Runtime.Serialization" />

--- a/Test/ElasticScale.ShardManagement.UnitTests/ShardMapFaultHandlingTests.cs
+++ b/Test/ElasticScale.ShardManagement.UnitTests/ShardMapFaultHandlingTests.cs
@@ -447,9 +447,9 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
                 CreateRemoveMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingGuid =
                 (_smm, _opcode, _sm, _mapping, _loid) => new RemoveMappingOperationFailAfterGlobalPreLocal(_smm, _opcode, _sm, _mapping, _loid),
 
-                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid =
-                (_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId)
-                    => new UpdateMappingOperationFailAfterGlobalPreLocal(_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId),
+                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool =
+                (_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId, _killConnection)
+                    => new UpdateMappingOperationFailAfterGlobalPreLocal(_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId, _killConnection),
 
                 CreateReplaceMappingsOperationShardMapManagerStoreOperationCodeIStoreShardMapTupleOfIStoreMappingGuidArrayTupleOfIStoreMappingGuidArray =
                 (_smm, _opcode, _sm, _mappingsource, _mappingtarget) => new ReplaceMappingsOperationFailAfterGlobalPreLocal(_smm, _opcode, _sm, _mappingsource, _mappingtarget)
@@ -518,7 +518,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
             // below call will only execute global pre-local step to create operations log
             RangeMapping<int> r2 = rsm.UpdateMapping(r1, ru);
 
-            ssof.CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid = null;
+            ssof.CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool = null;
 
             // now update same mapping again, this will undo previous pending operation and then add this mapping
 
@@ -526,14 +526,14 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
 
             // try mapping update failures with change in shard location
             // first reset CreateUpdateMappingOperation to just perform global pre-local
-            ssof.CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid =
-                (_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId)
-                    => new UpdateMappingOperationFailAfterGlobalPreLocal(_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId);
+            ssof.CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool =
+                (_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId, _killConnection)
+                    => new UpdateMappingOperationFailAfterGlobalPreLocal(_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId, _killConnection);
 
             RangeMapping<int> r4 = rsm.UpdateMapping(r3, new RangeMappingUpdate { Shard = s2 });
 
             // now try with actual update mapping operation
-            ssof.CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid = null;
+            ssof.CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool = null;
             RangeMapping<int> r5 = rsm.UpdateMapping(r3, new RangeMappingUpdate { Shard = s2 });
 
             // split mapping toperform gsm-only pre-local operation
@@ -577,9 +577,9 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
                 CreateRemoveMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingGuid =
                 (_smm, _opcode, _sm, _mapping, _loid) => new RemoveMappingOperationFailAfterLocalSource(_smm, _opcode, _sm, _mapping, _loid),
 
-                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid =
-                (_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId)
-                    => new UpdateMappingOperationFailAfterLocalSource(_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId),
+                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool =
+                (_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId, _killConnection)
+                    => new UpdateMappingOperationFailAfterLocalSource(_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId, _killConnection),
 
                 CreateReplaceMappingsOperationShardMapManagerStoreOperationCodeIStoreShardMapTupleOfIStoreMappingGuidArrayTupleOfIStoreMappingGuidArray =
                 (_smm, _opcode, _sm, _mappingsource, _mappingtarget) => new ReplaceMappingsOperationFailAfterLocalSource(_smm, _opcode, _sm, _mappingsource, _mappingtarget)
@@ -648,7 +648,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
             // below call will only execute global pre-local step to create operations log
             RangeMapping<int> r2 = rsm.UpdateMapping(r1, ru);
 
-            ssof.CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid = null;
+            ssof.CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool = null;
 
             // now update same mapping again, this will undo previous pending operation and then add this mapping
 
@@ -656,14 +656,14 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
 
             // try mapping update failures with change in shard location
             // first reset CreateUpdateMappingOperation to just perform global pre-local
-            ssof.CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid =
-                (_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId)
-                    => new UpdateMappingOperationFailAfterLocalSource(_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId);
+            ssof.CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool =
+                (_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId, _killConnection)
+                    => new UpdateMappingOperationFailAfterLocalSource(_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId, _killConnection);
 
             RangeMapping<int> r4 = rsm.UpdateMapping(r3, new RangeMappingUpdate { Shard = s2 });
 
             // now try with actual update mapping operation
-            ssof.CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid = null;
+            ssof.CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool = null;
             RangeMapping<int> r5 = rsm.UpdateMapping(r3, new RangeMappingUpdate { Shard = s2 });
 
             // split mapping toperform gsm-only pre-local operation
@@ -707,9 +707,9 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
                 CreateRemoveMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingGuid =
                 (_smm, _opcode, _sm, _mapping, _loid) => new RemoveMappingOperationFailAfterLocalTarget(_smm, _opcode, _sm, _mapping, _loid),
 
-                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid =
-                (_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId)
-                    => new UpdateMappingOperationFailAfterLocalTarget(_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId),
+                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool =
+                (_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId, _killConnection)
+                    => new UpdateMappingOperationFailAfterLocalTarget(_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId, _killConnection),
 
                 CreateReplaceMappingsOperationShardMapManagerStoreOperationCodeIStoreShardMapTupleOfIStoreMappingGuidArrayTupleOfIStoreMappingGuidArray =
                 (_smm, _opcode, _sm, _mappingsource, _mappingtarget) => new ReplaceMappingsOperationFailAfterLocalTarget(_smm, _opcode, _sm, _mappingsource, _mappingtarget)
@@ -778,7 +778,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
             // below call will only execute global pre-local step to create operations log
             RangeMapping<int> r2 = rsm.UpdateMapping(r1, ru);
 
-            ssof.CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid = null;
+            ssof.CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool = null;
 
             // now update same mapping again, this will undo previous pending operation and then add this mapping
 
@@ -786,14 +786,14 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
 
             // try mapping update failures with change in shard location
             // first reset CreateUpdateMappingOperation to just perform global pre-local
-            ssof.CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid =
-                (_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId)
-                    => new UpdateMappingOperationFailAfterLocalTarget(_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId);
+            ssof.CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool =
+                (_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId, _killConnection)
+                    => new UpdateMappingOperationFailAfterLocalTarget(_shardMapManager, _operationCode, _shardMap, _mappingSource, _mappingTarget, _patternForKill, _lockOwnerId, _killConnection);
 
             RangeMapping<int> r4 = rsm.UpdateMapping(r3, new RangeMappingUpdate { Shard = s2 });
 
             // now try with actual update mapping operation
-            ssof.CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid = null;
+            ssof.CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool = null;
             RangeMapping<int> r5 = rsm.UpdateMapping(r3, new RangeMappingUpdate { Shard = s2 });
 
             // split mapping toperform gsm-only pre-local operation
@@ -1008,7 +1008,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
                 IStoreMapping mappingSource,
                 IStoreMapping mappingTarget,
                 string patternForKill,
-                Guid lockOwnerId)
+                Guid lockOwnerId,
+                bool killConnection)
             : base(
                 shardMapManager,
                 operationCode,
@@ -1016,7 +1017,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
                 mappingSource,
                 mappingTarget,
                 patternForKill,
-                lockOwnerId)
+                lockOwnerId,
+                killConnection)
             {
             }
 
@@ -1241,7 +1243,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
                 IStoreMapping mappingSource,
                 IStoreMapping mappingTarget,
                 string patternForKill,
-                Guid lockOwnerId)
+                Guid lockOwnerId,
+                bool killConnection)
                 : base(
                     shardMapManager,
                     operationCode,
@@ -1249,7 +1252,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
                     mappingSource,
                     mappingTarget,
                     patternForKill,
-                    lockOwnerId)
+                    lockOwnerId,
+                    killConnection)
             {
             }
 
@@ -1425,7 +1429,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
                 IStoreMapping mappingSource,
                 IStoreMapping mappingTarget,
                 string patternForKill,
-                Guid lockOwnerId)
+                Guid lockOwnerId,
+                bool killConnection)
                 : base(
                     shardMapManager,
                     operationCode,
@@ -1433,7 +1438,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
                     mappingSource,
                     mappingTarget,
                     patternForKill,
-                    lockOwnerId)
+                    lockOwnerId,
+                    killConnection)
             {
             }
 

--- a/Test/ElasticScale.ShardManagement.UnitTests/ShardMapperTests.cs
+++ b/Test/ElasticScale.ShardManagement.UnitTests/ShardMapperTests.cs
@@ -3086,10 +3086,10 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
             IStoreOperationFactory sof = new StubStoreOperationFactory()
             {
                 CallBase = true,
-                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid =
-                (_smm, _opcode, _ssm, _sms, _smt, _p, _loid) =>
+                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool =
+                (_smm, _opcode, _ssm, _sms, _smt, _p, _loid, _kc) =>
                 {
-                    StubUpdateMappingOperation op = new StubUpdateMappingOperation(_smm, _opcode, _ssm, _sms, _smt, _p, _loid);
+                    StubUpdateMappingOperation op = new StubUpdateMappingOperation(_smm, _opcode, _ssm, _sms, _smt, _p, _loid, _kc);
                     op.CallBase = true;
                     op.DoGlobalPostLocalExecuteIStoreTransactionScope = (ts) =>
                     {
@@ -3158,10 +3158,10 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
             IStoreOperationFactory sof = new StubStoreOperationFactory()
             {
                 CallBase = true,
-                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid =
-                (_smm, _opcode, _ssm, _sms, _smt, _p, _loid) =>
+                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool =
+                (_smm, _opcode, _ssm, _sms, _smt, _p, _loid, _kc) =>
                 {
-                    StubUpdateMappingOperation op = new StubUpdateMappingOperation(_smm, _opcode, _ssm, _sms, _smt, _p, _loid);
+                    StubUpdateMappingOperation op = new StubUpdateMappingOperation(_smm, _opcode, _ssm, _sms, _smt, _p, _loid, _kc);
                     op.CallBase = true;
                     if (shouldThrow)
                     {
@@ -3394,10 +3394,10 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
             IStoreOperationFactory sof = new StubStoreOperationFactory()
             {
                 CallBase = true,
-                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid =
-                (_smm, _opcode, _ssm, _sms, _smt, _p, _loid) =>
+                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool =
+                (_smm, _opcode, _ssm, _sms, _smt, _p, _loid, _kc) =>
                 {
-                    StubUpdateMappingOperation op = new StubUpdateMappingOperation(_smm, _opcode, _ssm, _sms, _smt, _p, _loid);
+                    StubUpdateMappingOperation op = new StubUpdateMappingOperation(_smm, _opcode, _ssm, _sms, _smt, _p, _loid, _kc);
                     op.CallBase = true;
                     op.DoGlobalPostLocalExecuteIStoreTransactionScope = (ts) =>
                     {
@@ -3465,10 +3465,10 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
             IStoreOperationFactory sof = new StubStoreOperationFactory()
             {
                 CallBase = true,
-                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid =
-                (_smm, _opcode, _ssm, _sms, _smt, _p, _loid) =>
+                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool =
+                (_smm, _opcode, _ssm, _sms, _smt, _p, _loid, _kc) =>
                 {
-                    StubUpdateMappingOperation op = new StubUpdateMappingOperation(_smm, _opcode, _ssm, _sms, _smt, _p, _loid);
+                    StubUpdateMappingOperation op = new StubUpdateMappingOperation(_smm, _opcode, _ssm, _sms, _smt, _p, _loid, _kc);
                     op.CallBase = true;
                     if (shouldThrow)
                     {
@@ -3828,10 +3828,10 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
             IStoreOperationFactory sof = new StubStoreOperationFactory()
             {
                 CallBase = true,
-                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid =
-                (_smm, _opcode, _ssm, _sms, _smt, _p, _loid) =>
+                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool =
+                (_smm, _opcode, _ssm, _sms, _smt, _p, _loid, _kc) =>
                 {
-                    StubUpdateMappingOperation op = new StubUpdateMappingOperation(_smm, _opcode, _ssm, _sms, _smt, _p, _loid);
+                    StubUpdateMappingOperation op = new StubUpdateMappingOperation(_smm, _opcode, _ssm, _sms, _smt, _p, _loid, _kc);
                     op.CallBase = true;
                     op.DoLocalSourceExecuteIStoreTransactionScope = (ts) =>
                     {
@@ -3900,10 +3900,10 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
             IStoreOperationFactory sof = new StubStoreOperationFactory()
             {
                 CallBase = true,
-                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid =
-                (_smm, _opcode, _ssm, _sms, _smt, _p, _loid) =>
+                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool =
+                (_smm, _opcode, _ssm, _sms, _smt, _p, _loid, _kc) =>
                 {
-                    StubUpdateMappingOperation op = new StubUpdateMappingOperation(_smm, _opcode, _ssm, _sms, _smt, _p, _loid);
+                    StubUpdateMappingOperation op = new StubUpdateMappingOperation(_smm, _opcode, _ssm, _sms, _smt, _p, _loid, _kc);
                     op.CallBase = true;
                     if (shouldThrow)
                     {
@@ -4134,10 +4134,10 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
             IStoreOperationFactory sof = new StubStoreOperationFactory()
             {
                 CallBase = true,
-                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid =
-                (_smm, _opcode, _ssm, _sms, _smt, _p, _loid) =>
+                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool =
+                (_smm, _opcode, _ssm, _sms, _smt, _p, _loid, _kc) =>
                 {
-                    StubUpdateMappingOperation op = new StubUpdateMappingOperation(_smm, _opcode, _ssm, _sms, _smt, _p, _loid);
+                    StubUpdateMappingOperation op = new StubUpdateMappingOperation(_smm, _opcode, _ssm, _sms, _smt, _p, _loid, _kc);
                     op.CallBase = true;
                     op.DoLocalSourceExecuteIStoreTransactionScope = (ts) =>
                     {
@@ -4205,10 +4205,10 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
             IStoreOperationFactory sof = new StubStoreOperationFactory()
             {
                 CallBase = true,
-                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid =
-                (_smm, _opcode, _ssm, _sms, _smt, _p, _loid) =>
+                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool =
+                (_smm, _opcode, _ssm, _sms, _smt, _p, _loid, _kc) =>
                 {
-                    StubUpdateMappingOperation op = new StubUpdateMappingOperation(_smm, _opcode, _ssm, _sms, _smt, _p, _loid);
+                    StubUpdateMappingOperation op = new StubUpdateMappingOperation(_smm, _opcode, _ssm, _sms, _smt, _p, _loid, _kc);
                     op.CallBase = true;
                     if (shouldThrow)
                     {
@@ -4704,10 +4704,10 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
             IStoreOperationFactory sof = new StubStoreOperationFactory()
             {
                 CallBase = true,
-                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid =
-                (_smm, _opcode, _ssm, _sms, _smt, _p, _loid) =>
+                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool =
+                (_smm, _opcode, _ssm, _sms, _smt, _p, _loid, _kc) =>
                 {
-                    StubUpdateMappingOperation op = new StubUpdateMappingOperation(_smm, _opcode, _ssm, _sms, _smt, _p, _loid);
+                    StubUpdateMappingOperation op = new StubUpdateMappingOperation(_smm, _opcode, _ssm, _sms, _smt, _p, _loid, _kc);
                     op.CallBase = true;
                     op.DoGlobalPostLocalExecuteIStoreTransactionScope = (ts) =>
                     {
@@ -4822,10 +4822,10 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
             IStoreOperationFactory sof = new StubStoreOperationFactory()
             {
                 CallBase = true,
-                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid =
-                (_smm, _opcode, _ssm, _sms, _smt, _p, _loid) =>
+                CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool =
+                (_smm, _opcode, _ssm, _sms, _smt, _p, _loid, _kc) =>
                 {
-                    StubUpdateMappingOperation op = new StubUpdateMappingOperation(_smm, _opcode, _ssm, _sms, _smt, _p, _loid);
+                    StubUpdateMappingOperation op = new StubUpdateMappingOperation(_smm, _opcode, _ssm, _sms, _smt, _p, _loid, _kc);
                     op.CallBase = true;
                     op.DoGlobalPostLocalExecuteIStoreTransactionScope = (ts) =>
                     {

--- a/Test/ElasticScale.ShardManagement.UnitTests/Stubs/StubStoreOperationFactory.cs
+++ b/Test/ElasticScale.ShardManagement.UnitTests/Stubs/StubStoreOperationFactory.cs
@@ -156,9 +156,9 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests.Stu
         /// </summary>
         internal Func<StoreOperationCode, ShardMapManager, Guid, StoreOperationState, XElement, Guid, IStoreOperation> CreateReplaceMappingsOperationStoreOperationCodeShardMapManagerGuidStoreOperationStateXElementGuid;
         /// <summary>
-        /// Sets the stub of StoreOperationFactory.CreateUpdateMappingOperation(ShardMapManager shardMapManager, StoreOperationCode operationCode, IStoreShardMap shardMap, IStoreMapping mappingSource, IStoreMapping mappingTarget, String patternForKill, Guid lockOwnerId)
+        /// Sets the stub of StoreOperationFactory.CreateUpdateMappingOperation(ShardMapManager shardMapManager, StoreOperationCode operationCode, IStoreShardMap shardMap, IStoreMapping mappingSource, IStoreMapping mappingTarget, String patternForKill, Guid lockOwnerId, Bool killConnection)
         /// </summary>
-        internal Func<ShardMapManager, StoreOperationCode, IStoreShardMap, IStoreMapping, IStoreMapping, string, Guid, IStoreOperation> CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid;
+        internal Func<ShardMapManager, StoreOperationCode, IStoreShardMap, IStoreMapping, IStoreMapping, string, Guid, bool, IStoreOperation> CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool;
         /// <summary>
         /// Sets the stub of StoreOperationFactory.CreateUpdateMappingOperation(StoreOperationCode operationCode, ShardMapManager shardMapManager, Guid operationId, StoreOperationState undoStartState, XElement root, Guid originalShardVersionRemoves, Guid originalShardVersionAdds)
         /// </summary>
@@ -669,15 +669,15 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests.Stu
         }
 
         /// <summary>
-        /// Sets the stub of StoreOperationFactory.CreateUpdateMappingOperation(ShardMapManager shardMapManager, StoreOperationCode operationCode, IStoreShardMap shardMap, IStoreMapping mappingSource, IStoreMapping mappingTarget, String patternForKill, Guid lockOwnerId)
+        /// Sets the stub of StoreOperationFactory.CreateUpdateMappingOperation(ShardMapManager shardMapManager, StoreOperationCode operationCode, IStoreShardMap shardMap, IStoreMapping mappingSource, IStoreMapping mappingTarget, String patternForKill, Guid lockOwnerId, bool KillConnection)
         /// </summary>
-        public override IStoreOperation CreateUpdateMappingOperation(ShardMapManager shardMapManager, StoreOperationCode operationCode, IStoreShardMap shardMap, IStoreMapping mappingSource, IStoreMapping mappingTarget, string patternForKill, Guid lockOwnerId)
+        public override IStoreOperation CreateUpdateMappingOperation(ShardMapManager shardMapManager, StoreOperationCode operationCode, IStoreShardMap shardMap, IStoreMapping mappingSource, IStoreMapping mappingTarget, string patternForKill, Guid lockOwnerId, bool killConnection)
         {
-            Func<ShardMapManager, StoreOperationCode, IStoreShardMap, IStoreMapping, IStoreMapping, string, Guid, IStoreOperation> func1 = this.CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuid;
+            Func<ShardMapManager, StoreOperationCode, IStoreShardMap, IStoreMapping, IStoreMapping, string, Guid, bool, IStoreOperation> func1 = this.CreateUpdateMappingOperationShardMapManagerStoreOperationCodeIStoreShardMapIStoreMappingIStoreMappingStringGuidBool;
             if (func1 != null)
-                return func1(shardMapManager, operationCode, shardMap, mappingSource, mappingTarget, patternForKill, lockOwnerId);
+                return func1(shardMapManager, operationCode, shardMap, mappingSource, mappingTarget, patternForKill, lockOwnerId, killConnection);
             if (this.___callBase)
-                return base.CreateUpdateMappingOperation(shardMapManager, operationCode, shardMap, mappingSource, mappingTarget, patternForKill, lockOwnerId);
+                return base.CreateUpdateMappingOperation(shardMapManager, operationCode, shardMap, mappingSource, mappingTarget, patternForKill, lockOwnerId, killConnection);
             return this.InstanceBehavior.Result<StubStoreOperationFactory, IStoreOperation>(this, "CreateUpdateMappingOperation");
         }
 

--- a/Test/ElasticScale.ShardManagement.UnitTests/Stubs/StubUpdateMappingOperation.cs
+++ b/Test/ElasticScale.ShardManagement.UnitTests/Stubs/StubUpdateMappingOperation.cs
@@ -189,8 +189,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests.Stu
         /// <summary>
         /// Initializes a new instance
         /// </summary>
-        public StubUpdateMappingOperation(ShardMapManager shardMapManager, StoreOperationCode operationCode, IStoreShardMap shardMap, IStoreMapping mappingSource, IStoreMapping mappingTarget, string patternForKill, Guid lockOwnerId)
-          : base(shardMapManager, operationCode, shardMap, mappingSource, mappingTarget, patternForKill, lockOwnerId)
+        public StubUpdateMappingOperation(ShardMapManager shardMapManager, StoreOperationCode operationCode, IStoreShardMap shardMap, IStoreMapping mappingSource, IStoreMapping mappingTarget, string patternForKill, Guid lockOwnerId, bool killConnection)
+          : base(shardMapManager, operationCode, shardMap, mappingSource, mappingTarget, patternForKill, lockOwnerId, killConnection)
         {
             this.InitializeStub();
         }


### PR DESCRIPTION
MappingOptions allow a user to specify if validation should be performed
on the affected shard in a mapping.  When a mapping is taken offline,
users can specify whether or not they want open connections
to affected shard from being killed.