### PR TITLE
Enable SecureString (via SqlCredential) for all APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ TestResults
 *.GhostDoc.xml
 *.suo
 *.pd_
+/.vs

--- a/Src/ElasticScale.Client/Microsoft.Azure.SqlDatabase.ElasticScale.Client.xml
+++ b/Src/ElasticScale.Client/Microsoft.Azure.SqlDatabase.ElasticScale.Client.xml
@@ -2332,6 +2332,11 @@
               Looks up a localized string similar to The low value {0} is greater than or equal to the high value {1}. Lower value must be less than the higher value..
             </summary>
         </member>
+        <member name="P:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.Errors._SqlShardMapManagerCredentials_ConnectionStringPropertyNotAllowed">
+            <summary>
+              Looks up a localized string similar to The required property &apos;{0}&apos; must not be set in the connection string..
+            </summary>
+        </member>
         <member name="P:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.Errors._SqlShardMapManagerCredentials_ConnectionStringPropertyRequired">
             <summary>
               Looks up a localized string similar to The required property &apos;{0}&apos; must be set in the connection string..
@@ -4165,10 +4170,28 @@
         </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.SqlStoreConnection.#ctor(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreConnectionKind,System.String)">
             <summary>
-            Constructs an instance of Sql Store Connection.
+            Initializes a new instance of the <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.SqlStoreConnection"/> class. 
             </summary>
-            <param name="kind">Type of store connection.</param>
-            <param name="connectionString"></param>
+            <param name="kind">
+            Type of store connection.
+            </param>
+            <param name="connectionString">
+            The SQL connection string
+            </param>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.SqlStoreConnection.#ctor(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreConnectionKind,System.String,System.Data.SqlClient.SqlCredential)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.SqlStoreConnection"/> class. 
+            </summary>
+            <param name="kind">
+            Type of store connection.
+            </param>
+            <param name="connectionString">
+            The SQL connection string
+            </param>
+            <param name="secureCredential">
+            The secure SQL Credential.
+            </param>
         </member>
         <member name="P:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.SqlStoreConnection.Kind">
             <summary>
@@ -4251,11 +4274,28 @@
             <param name="connectionString">Connection string for store.</param>
             <returns>An unopened instance of the store connection.</returns>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.SqlStoreConnectionFactory.GetConnection(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreConnectionKind,System.String,System.Data.SqlClient.SqlCredential)">
+            <summary>
+            Constructs a new instance of store connection.
+            </summary>
+            <param name="kind">Type of store connection.</param>
+            <param name="connectionString">Connection string for store.</param>
+            <param name="secureCredential">Secure Credential for store.</param>
+            <returns>An unopened instance of the store connection.</returns>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.SqlStoreConnectionFactory.GetUserConnection(System.String)">
             <summary>
             Constructs a new instance of user connection.
             </summary>
             <param name="connectionString">Connection string of user.</param>
+            <returns>An unopened instance of the user connection.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.SqlStoreConnectionFactory.GetUserConnection(System.String,System.Data.SqlClient.SqlCredential)">
+            <summary>
+            Constructs a new instance of user connection.
+            </summary>
+            <param name="connectionString">Connection string of user.</param>
+            <param name="secureCredential">Secure Credential of user</param>
             <returns>An unopened instance of the user connection.</returns>
         </member>
         <member name="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.SqlUserStoreConnection">
@@ -4268,11 +4308,12 @@
             Underlying connection.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.SqlUserStoreConnection.#ctor(System.String)">
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.SqlUserStoreConnection.#ctor(System.String,System.Data.SqlClient.SqlCredential)">
             <summary>
             Creates a new instance of user store connection.
             </summary>
             <param name="connectionString">Connection string.</param>
+            <param name="secureCredential">Secure SQL Credential.</param>
         </member>
         <member name="P:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.SqlUserStoreConnection.Connection">
             <summary>
@@ -8109,6 +8150,12 @@
             </summary>
             <returns>Connection string for LSM given its location.</returns>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperation.GetSecureCredentialForShardLocation(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardLocation)">
+            <summary>
+            Obtains the Secure Credential for an LSM location.
+            </summary>
+            <returns>Connection string for LSM given its location.</returns>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperation.UndoStateForDoState(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreOperationState)">
             <summary>
             Given a state of the Do operation progress, gets the corresponding starting point
@@ -9667,16 +9714,40 @@
             Connection string for individual shards.
             </summary>
         </member>
+        <member name="F:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.SqlShardMapManagerCredentials._secureCredential">
+            <summary>
+            Secure credential for shard map manager data source.
+            </summary>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.SqlShardMapManagerCredentials.#ctor(System.String)">
             <summary>
             Instantiates the object that holds the credentials for accessing SQL Servers 
             containing the shard map manager data.
             </summary>
-            <param name="connectionString">Connection string for Shard map manager data source.</param>
+            <param name="connectionString">
+            Connection string for shard map manager data source.
+            </param>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.SqlShardMapManagerCredentials.#ctor(System.String,System.Data.SqlClient.SqlCredential)">
+            <summary>
+            Instantiates the object that holds the credentials for accessing SQL Servers 
+            containing the shard map manager data.
+            </summary>
+            <param name="connectionString">
+            Connection string for shard map manager data source.
+            </param>
+            <param name="secureCredential">
+             Secure credential for shard map manager data source.
+            </param>
         </member>
         <member name="P:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.SqlShardMapManagerCredentials.ConnectionStringShardMapManager">
             <summary>
             Connection string for shard map manager database.
+            </summary>
+        </member>
+        <member name="P:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.SqlShardMapManagerCredentials.SecureCredentialShardMapManager">
+            <summary>
+            Secure Credential for shard map manager database.
             </summary>
         </member>
         <member name="P:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.SqlShardMapManagerCredentials.ConnectionStringShard">
@@ -9689,12 +9760,19 @@
             Location of Shard Map Manager used for logging purpose.
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.SqlShardMapManagerCredentials.EnsureCredentials(System.Data.SqlClient.SqlConnectionStringBuilder,System.String)">
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.SqlShardMapManagerCredentials.EnsureCredentials(System.Data.SqlClient.SqlConnectionStringBuilder,System.String,System.Data.SqlClient.SqlCredential)">
             <summary>
             Ensures that credentials are provided for the given connection string object.
             </summary>
-            <param name="connectionString">Input connection string object.</param>
-            <param name="parameterName">Parameter name of the connection string object.</param>
+            <param name="connectionString">
+            Input connection string object.
+            </param>
+            <param name="parameterName">
+            Parameter name of the connection string object.
+            </param>
+            <param name="secureCredential">
+            Input secure SQL credential object.
+            </param>
         </member>
         <member name="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.BaseShardMapper">
             <summary>
@@ -9759,6 +9837,24 @@
             <param name="options">Options for validation operations to perform on opened connection.</param>
             <returns>An opened SqlConnection.</returns>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.BaseShardMapper.OpenConnectionForKey``2(``1,System.Func{Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMap,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,``0},Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardManagementErrorCategory,System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
+            <summary>
+            Given a key value, obtains a SqlConnection to the shard in the mapping
+            that contains the key value.
+            </summary>
+            <typeparam name="TMapping">Mapping type.</typeparam>
+            <typeparam name="TKey">Key type.</typeparam>
+            <param name="key">Input key value.</param>
+            <param name="constructMapping">Delegate to construct a mapping object.</param>
+            <param name="errorCategory">Error category.</param>
+            <param name="connectionString">
+            Connection string with credential information, the DataSource and Database are 
+            obtained from the results of the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure Sql credential information</param>
+            <param name="options">Options for validation operations to perform on opened connection.</param>
+            <returns>An opened SqlConnection.</returns>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.BaseShardMapper.OpenConnectionForKeyAsync``2(``1,System.Func{Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMap,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,``0},Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardManagementErrorCategory,System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
             <summary>
             Given a key value, asynchronously obtains a SqlConnection to the shard in the mapping
@@ -9773,6 +9869,24 @@
             Connection string with credential information, the DataSource and Database are 
             obtained from the results of the lookup operation for key.
             </param>
+            <param name="options">Options for validation operations to perform on opened connection.</param>
+            <returns>A task encapsulating an opened SqlConnection as the result.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.BaseShardMapper.OpenConnectionForKeyAsync``2(``1,System.Func{Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMap,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreMapping,``0},Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardManagementErrorCategory,System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
+            <summary>
+            Given a key value, asynchronously obtains a SqlConnection to the shard in the mapping
+            that contains the key value.
+            </summary>
+            <typeparam name="TMapping">Mapping type.</typeparam>
+            <typeparam name="TKey">Key type.</typeparam>
+            <param name="key">Input key value.</param>
+            <param name="constructMapping">Delegate to construct a mapping object.</param>
+            <param name="errorCategory">Error category.</param>
+            <param name="connectionString">
+            Connection string with credential information, the DataSource and Database are 
+            obtained from the results of the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure SQL Credential.</param>
             <param name="options">Options for validation operations to perform on opened connection.</param>
             <returns>A task encapsulating an opened SqlConnection as the result.</returns>
         </member>
@@ -9898,6 +10012,19 @@
             <param name="options">Options for validation operations to perform on opened connection.</param>
             <returns>An opened SqlConnection.</returns>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.DefaultShardMapper.OpenConnectionForKey(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.Shard,System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
+            <summary>
+            Given a shard, obtains a SqlConnection to the shard. The shard must exist in the mapper.
+            </summary>
+            <param name="key">Input shard.</param>
+            <param name="connectionString">
+            Connection string with credential information, the DataSource and Database are 
+            obtained from the results of the lookup operation.
+            </param>
+            <param name="secureCredential">Secure SQL credential.</param>
+            <param name="options">Options for validation operations to perform on opened connection.</param>
+            <returns>An opened SqlConnection.</returns>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.DefaultShardMapper.OpenConnectionForKeyAsync(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.Shard,System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
             <summary>
             Given a shard, asynchronously obtains a SqlConnection to the shard. The shard must exist in the mapper.
@@ -9907,6 +10034,19 @@
             Connection string with credential information, the DataSource and Database are 
             obtained from the results of the lookup operation.
             </param>
+            <param name="options">Options for validation operations to perform on opened connection.</param>
+            <returns>An opened SqlConnection.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.DefaultShardMapper.OpenConnectionForKeyAsync(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.Shard,System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
+            <summary>
+            Given a shard, asynchronously obtains a SqlConnection to the shard. The shard must exist in the mapper.
+            </summary>
+            <param name="key">Input shard.</param>
+            <param name="connectionString">
+            Connection string with credential information, the DataSource and Database are 
+            obtained from the results of the lookup operation.
+            </param>
+            <param name="secureCredential">Secure SQL credential.</param>
             <param name="options">Options for validation operations to perform on opened connection.</param>
             <returns>An opened SqlConnection.</returns>
         </member>
@@ -10025,6 +10165,20 @@
             <param name="options">Options for validation operations to perform on opened connection.</param>
             <returns>An opened SqlConnection.</returns>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IShardMapper`1.OpenConnectionForKey(`0,System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
+            <summary>
+            Given a key value, obtains a SqlConnection to the shard in the mapping
+            that contains the key value.
+            </summary>
+            <param name="key">Input key value.</param>
+            <param name="connectionString">
+            Connection string with credential information, the DataSource and Database are 
+            obtained from the results of the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure SQL Credential.</param>
+            <param name="options">Options for validation operations to perform on opened connection.</param>
+            <returns>An opened SqlConnection.</returns>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IShardMapper`1.OpenConnectionForKeyAsync(`0,System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
             <summary>
             Given a key value, asynchronously obtains a SqlConnection to the shard in the mapping
@@ -10035,6 +10189,20 @@
             Connection string with credential information, the DataSource and Database are 
             obtained from the results of the lookup operation for key.
             </param>
+            <param name="options">Options for validation operations to perform on opened connection.</param>
+            <returns>An opened SqlConnection.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IShardMapper`1.OpenConnectionForKeyAsync(`0,System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
+            <summary>
+            Given a key value, asynchronously obtains a SqlConnection to the shard in the mapping
+            that contains the key value.
+            </summary>
+            <param name="key">Input key value.</param>
+            <param name="connectionString">
+            Connection string with credential information, the DataSource and Database are 
+            obtained from the results of the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure SQL Credential.</param>
             <param name="options">Options for validation operations to perform on opened connection.</param>
             <returns>An opened SqlConnection.</returns>
         </member>
@@ -10102,6 +10270,20 @@
             <param name="options">Options for validation operations to perform on opened connection.</param>
             <returns>An opened SqlConnection.</returns>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ListShardMapper`1.OpenConnectionForKey(`0,System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
+            <summary>
+            Given a key value, obtains a SqlConnection to the shard in the mapping
+            that contains the key value.
+            </summary>
+            <param name="key">Input key value.</param>
+            <param name="connectionString">
+            Connection string with credential information, the DataSource and Database are 
+            obtained from the results of the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure Sql Credential.</param>
+            <param name="options">Options for validation operations to perform on opened connection.</param>
+            <returns>An opened SqlConnection.</returns>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ListShardMapper`1.OpenConnectionForKeyAsync(`0,System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
             <summary>
             Given a key value, asynchronously obtains a SqlConnection to the shard in the mapping
@@ -10109,6 +10291,21 @@
             </summary>
             <param name="key">Input key value.</param>
             <param name="connectionString">
+            Connection string with credential information, the DataSource and Database are 
+            obtained from the results of the lookup operation for key.
+            </param>
+            <param name="options">Options for validation operations to perform on opened connection.</param>
+            <returns>A Task encapsulating an opened SqlConnection.</returns>
+            <remarks>All non usage-error exceptions will be reported via the returned Task</remarks>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ListShardMapper`1.OpenConnectionForKeyAsync(`0,System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
+            <summary>
+            Given a key value, asynchronously obtains a SqlConnection to the shard in the mapping
+            that contains the key value.
+            </summary>
+            <param name="key">Input key value.</param>
+            <param name="connectionString">
+            <param name="secureCredential">Secure SQL Credential.</param>
             Connection string with credential information, the DataSource and Database are 
             obtained from the results of the lookup operation for key.
             </param>
@@ -10224,6 +10421,20 @@
             <param name="options">Options for validation operations to perform on opened connection.</param>
             <returns>An opened SqlConnection.</returns>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeShardMapper`1.OpenConnectionForKey(`0,System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
+            <summary>
+            Given a key value, obtains a SqlConnection to the shard in the mapping
+            that contains the key value.
+            </summary>
+            <param name="key">Input key value.</param>
+            <param name="connectionString">
+            Connection string with credential information, the DataSource and Database are 
+            obtained from the results of the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure SQL Credential.</param>
+            <param name="options">Options for validation operations to perform on opened connection.</param>
+            <returns>An opened SqlConnection.</returns>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeShardMapper`1.OpenConnectionForKeyAsync(`0,System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
             <summary>
             Given a key value, asynchronously obtains a SqlConnection to the shard in the mapping
@@ -10234,6 +10445,20 @@
             Connection string with credential information, the DataSource and Database are 
             obtained from the results of the lookup operation for key.
             </param>
+            <param name="options">Options for validation operations to perform on opened connection.</param>
+            <returns>A Task encapsulating an opened SqlConnection.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeShardMapper`1.OpenConnectionForKeyAsync(`0,System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
+            <summary>
+            Given a key value, asynchronously obtains a SqlConnection to the shard in the mapping
+            that contains the key value.
+            </summary>
+            <param name="key">Input key value.</param>
+            <param name="connectionString">
+            Connection string with credential information, the DataSource and Database are 
+            obtained from the results of the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure SQL Credential.</param>
             <param name="options">Options for validation operations to perform on opened connection.</param>
             <returns>A Task encapsulating an opened SqlConnection.</returns>
         </member>
@@ -11559,6 +11784,21 @@
             functionality in the Enterprise Library from Microsoft Patterns and Practices team.
             </remarks>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.Shard.OpenConnection(System.String,System.Data.SqlClient.SqlCredential)">
+            <summary>
+            Opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the specified shard, with <see cref="F:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions.Validate"/>.
+            </summary>
+            <param name="connectionString">
+            Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+            The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure Sql credential information.</param>
+            <remarks>
+            Note that the <see cref="T:System.Data.SqlClient.SqlConnection"/> object returned by this call is not protected against transient faults. 
+            Callers should follow best practices to protect the connection against transient faults in their application code, e.g., by using the transient fault handling 
+            functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+            </remarks>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.Shard.OpenConnection(System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
             <summary>
             Opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the specified shard.
@@ -11567,6 +11807,22 @@
             Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
             The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
             </param>
+            <param name="options">Options for validation operations to perform on opened connection.</param>
+            <remarks>
+            Note that the <see cref="T:System.Data.SqlClient.SqlConnection"/> object returned by this call is not protected against transient faults. 
+            Callers should follow best practices to protect the connection against transient faults in their application code, e.g., by using the transient fault handling 
+            functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.Shard.OpenConnection(System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
+            <summary>
+            Opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the specified shard.
+            </summary>
+            <param name="connectionString">
+            Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+            The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure SQL credential information.</param>
             <param name="options">Options for validation operations to perform on opened connection.</param>
             <remarks>
             Note that the <see cref="T:System.Data.SqlClient.SqlConnection"/> object returned by this call is not protected against transient faults. 
@@ -11590,6 +11846,23 @@
             All non-usage errors will be propagated via the returned Task.
             </remarks>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.Shard.OpenConnectionAsync(System.String,System.Data.SqlClient.SqlCredential)">
+            <summary>
+            Asynchronously opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the specified shard, with <see cref="F:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions.Validate"/>.
+            </summary>
+            <param name="connectionString">
+            Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+            The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure SQL Credential.</param>
+            <returns>A Task encapsulating an opened SqlConnection</returns>
+            <remarks>
+            Note that the <see cref="T:System.Data.SqlClient.SqlConnection"/> object returned by this call is not protected against transient faults. 
+            Callers should follow best practices to protect the connection against transient faults in their application code, e.g., by using the transient fault handling 
+            functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+            All non-usage errors will be propagated via the returned Task.
+            </remarks>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.Shard.OpenConnectionAsync(System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
             <summary>
             Asynchronously a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the specified shard.
@@ -11598,6 +11871,24 @@
             Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
             The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
             </param>
+            <param name="options">Options for validation operations to perform on opened connection.</param>
+            <returns>A Task encapsulating an opened SqlConnection</returns>
+            <remarks>
+            Note that the <see cref="T:System.Data.SqlClient.SqlConnection"/> object returned by this call is not protected against transient faults. 
+            Callers should follow best practices to protect the connection against transient faults in their application code, e.g., by using the transient fault handling 
+            functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+            All non-usage errors will be propagated via the returned Task.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.Shard.OpenConnectionAsync(System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
+            <summary>
+            Asynchronously a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the specified shard.
+            </summary>
+            <param name="connectionString">
+            Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+            The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure SQL Credential.</param>
             <param name="options">Options for validation operations to perform on opened connection.</param>
             <returns>A Task encapsulating an opened SqlConnection</returns>
             <remarks>
@@ -11965,12 +12256,37 @@
             shard maps, shards and shard mappings.
             </returns>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.CreateSqlShardMapManager(System.String,System.Data.SqlClient.SqlCredential)">
+            <summary>
+            Creates a <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager"/> and its corresponding storage structures in the specified SQL Server database,
+            with <see cref="F:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerCreateMode.KeepExisting"/> and <see cref="P:Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior.DefaultRetryBehavior"/>.
+            </summary>
+            <param name="connectionString">Connection parameters used for creating shard map manager database.</param>
+            <param name="secureCredential">Secure credential used for creating shard map manager database.</param>
+            <returns>
+            A shard map manager object used for performing management and read operations for
+            shard maps, shards and shard mappings.
+            </returns>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.CreateSqlShardMapManager(System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerCreateMode)">
             <summary>
             Creates a <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager"/> and its corresponding storage structures in the specified SQL Server database, 
             with <see cref="P:Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior.DefaultRetryBehavior"/>.
             </summary>
             <param name="connectionString">Connection parameters used for creating shard map manager database.</param>
+            <param name="createMode">Describes the option selected by the user for creating shard map manager database.</param>
+            <returns>
+            A shard map manager object used for performing management and read operations for
+            shard maps, shards and shard mappings.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.CreateSqlShardMapManager(System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerCreateMode)">
+            <summary>
+            Creates a <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager"/> and its corresponding storage structures in the specified SQL Server database, 
+            with <see cref="P:Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior.DefaultRetryBehavior"/>.
+            </summary>
+            <param name="connectionString">Connection parameters used for creating shard map manager database.</param>
+            <param name="secureCredential">Secure credential used for creating shard map manager database.</param>
             <param name="createMode">Describes the option selected by the user for creating shard map manager database.</param>
             <returns>
             A shard map manager object used for performing management and read operations for
@@ -11986,6 +12302,16 @@
             <param name="createMode">Describes the option selected by the user for creating shard map manager database.</param>
             <param name="targetVersion">Target version of store to create.</param>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.CreateSqlShardMapManager(System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerCreateMode,System.Version)">
+            <summary>
+            Creates a <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager"/> and its corresponding storage structures in the specified SQL Server database, 
+            with <see cref="P:Microsoft.Azure.SqlDatabase.ElasticScale.RetryPolicy.DefaultRetryPolicy"/>.
+            </summary>
+            <param name="connectionString">Connection parameters used for creating shard map manager database.</param>
+            <param name="secureCredential">Secure credential used for creating shard map manager database.</param>
+            <param name="createMode">Describes the option selected by the user for creating shard map manager database.</param>
+            <param name="targetVersion">Target version of store to create.</param>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.CreateSqlShardMapManager(System.String,Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior)">
             <summary>
             Creates a <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager"/> and its corresponding storage structures in the specified SQL Server database,
@@ -11998,11 +12324,37 @@
             shard maps, shards and shard mappings.
             </returns>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.CreateSqlShardMapManager(System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior)">
+            <summary>
+            Creates a <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager"/> and its corresponding storage structures in the specified SQL Server database,
+            with <see cref="F:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerCreateMode.KeepExisting"/>.
+            </summary>
+            <param name="connectionString">Connection parameters used for creating shard map manager database.</param>
+            <param name="secureCredential">Secure credential used for creating shard map manager database.</param>
+            <param name="retryBehavior">Behavior for detecting transient exceptions in the store.</param>
+            <returns>
+            A shard map manager object used for performing management and read operations for
+            shard maps, shards and shard mappings.
+            </returns>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.CreateSqlShardMapManager(System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerCreateMode,Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior)">
             <summary>
             Creates a <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager"/> and its corresponding storage structures in the specified SQL Server database.
             </summary>
             <param name="connectionString">Connection parameters used for creating shard map manager database.</param>
+            <param name="createMode">Describes the option selected by the user for creating shard map manager database.</param>
+            <param name="retryBehavior">Behavior for detecting transient exceptions in the store.</param>
+            <returns>
+            A shard map manager object used for performing management and read operations for
+            shard maps, shards and shard mappings.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.CreateSqlShardMapManager(System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerCreateMode,Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior)">
+            <summary>
+            Creates a <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager"/> and its corresponding storage structures in the specified SQL Server database.
+            </summary>
+            <param name="connectionString">Connection parameters used for creating shard map manager database.</param>
+            <param name="secureCredential">Secure credential used for creating shard map manager database.</param>
             <param name="createMode">Describes the option selected by the user for creating shard map manager database.</param>
             <param name="retryBehavior">Behavior for detecting transient exceptions in the store.</param>
             <returns>
@@ -12023,15 +12375,30 @@
             shard maps, shards and shard mappings.
             </returns>
         </member>
-        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.CreateSqlShardMapManagerImpl(System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerCreateMode,Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior,System.EventHandler{Microsoft.Azure.SqlDatabase.ElasticScale.RetryingEventArgs},System.Version)">
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.CreateSqlShardMapManager(System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerCreateMode,Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior,System.EventHandler{Microsoft.Azure.SqlDatabase.ElasticScale.RetryingEventArgs})">
             <summary>
             Creates a <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager"/> and its corresponding storage structures in the specified SQL Server database.
             </summary>
             <param name="connectionString">Connection parameters used for creating shard map manager database.</param>
+            <param name="secureCredential">Secure credential used for creating shard map manager database.</param>
+            <param name="createMode">Describes the option selected by the user for creating shard map manager database.</param>
+            <param name="retryBehavior">Behavior for detecting transient exceptions in the store.</param>
+            <param name="retryEventHandler">Event handler for store operation retry events.</param>
+            <returns>
+            A shard map manager object used for performing management and read operations for
+            shard maps, shards and shard mappings.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.CreateSqlShardMapManagerImpl(System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerCreateMode,Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior,System.EventHandler{Microsoft.Azure.SqlDatabase.ElasticScale.RetryingEventArgs},System.Version)">
+            <summary>
+            Creates a <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager"/> and its corresponding storage structures in the specified SQL Server database.
+            </summary>
+            <param name="connectionString">Connection parameters used for creating shard map manager database.</param>
+            <param name="secureCredential">Secure credential used for creating shard map manager database.</param>
             <param name="createMode">Describes the option selected by the user for creating shard map manager database.</param>
             <param name="retryBehavior">Behavior for performing retries on connections to shard map manager database.</param>
-            <param name="targetVersion">Target version of Store to deploy, this is mainly used for upgrade testing.</param>
             <param name="retryEventHandler">Event handler for store operation retry events.</param>
+            <param name="targetVersion">Target version of Store to deploy, this is mainly used for upgrade testing.</param>
             <returns>
             A shard map manager object used for performing management and read operations for
             shard maps, shards and shard mappings.
@@ -12049,29 +12416,57 @@
             <c>true</c> if a shard map manager object was created, <c>false</c> otherwise.
             </returns>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.TryGetSqlShardMapManager(System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerLoadPolicy,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager@)">
+            <summary>
+            Gets <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager"/> from persisted state in a SQL Server database.
+            </summary>
+            <param name="connectionString">Connection parameters used for performing operations against shard map manager database(s).</param>
+            <param name="secureCredential">Secure credential used for performing operations against shard map manager database(s).</param>
+            <param name="loadPolicy">Initialization policy.</param>
+            <param name="shardMapManager">Shard map manager object used for performing management and read operations for shard maps, 
+                shards and shard mappings or <c>null</c> in case shard map manager does not exist.</param>
+            <returns>
+            <c>true</c> if a shard map manager object was created, <c>false</c> otherwise.
+            </returns>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.TryGetSqlShardMapManager(System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerLoadPolicy,Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager@)">
             <summary>
             Gets <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager"/> from persisted state in a SQL Server database.
             </summary>
             <param name="connectionString">Connection parameters used for performing operations against shard map manager database(s).</param>
             <param name="loadPolicy">Initialization policy.</param>
-            <param name="shardMapManager">Shard map manager object used for performing management and read operations for shard maps, 
-            shards and shard mappings or <c>null</c> in case shard map manager does not exist.</param>
             <param name="retryBehavior">Behavior for detecting transient exceptions in the store.</param>
+            <param name="shardMapManager">Shard map manager object used for performing management and read operations for shard maps, 
+                shards and shard mappings or <c>null</c> in case shard map manager does not exist.</param>
             <returns>
             <c>true</c> if a shard map manager object was created, <c>false</c> otherwise.
             </returns>
         </member>
-        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.TryGetSqlShardMapManager(System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerLoadPolicy,Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior,System.EventHandler{Microsoft.Azure.SqlDatabase.ElasticScale.RetryingEventArgs},Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager@)">
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.TryGetSqlShardMapManager(System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerLoadPolicy,Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager@)">
             <summary>
             Gets <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager"/> from persisted state in a SQL Server database.
             </summary>
             <param name="connectionString">Connection parameters used for performing operations against shard map manager database(s).</param>
+            <param name="secureCredential">Secure credential used for performing operations against shard map manager database(s).</param>
             <param name="loadPolicy">Initialization policy.</param>
+            <param name="retryBehavior">Behavior for detecting transient exceptions in the store.</param>
             <param name="shardMapManager">Shard map manager object used for performing management and read operations for shard maps, 
-            shards and shard mappings or <c>null</c> in case shard map manager does not exist.</param>
+                shards and shard mappings or <c>null</c> in case shard map manager does not exist.</param>
+            <returns>
+            <c>true</c> if a shard map manager object was created, <c>false</c> otherwise.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.TryGetSqlShardMapManager(System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerLoadPolicy,Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior,System.EventHandler{Microsoft.Azure.SqlDatabase.ElasticScale.RetryingEventArgs},Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager@)">
+            <summary>
+            Gets <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager"/> from persisted state in a SQL Server database.
+            </summary>
+            <param name="connectionString">Connection parameters used for performing operations against shard map manager database(s).</param>
+            <param name="secureCredential">Secure credential used for performing operations against shard map manager database(s).</param>
+            <param name="loadPolicy">Initialization policy.</param>
             <param name="retryBehavior">Behavior for detecting transient exceptions in the store.</param>
             <param name="retryEventHandler">Event handler for store operation retry events.</param>
+            <param name="shardMapManager">Shard map manager object used for performing management and read operations for shard maps, 
+                shards and shard mappings or <c>null</c> in case shard map manager does not exist.</param>
             <returns>
             <c>true</c> if a shard map manager object was created, <c>false</c> otherwise.
             </returns>
@@ -12081,6 +12476,18 @@
             Gets <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager"/> from persisted state in a SQL Server database, with <see cref="P:Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior.DefaultRetryBehavior"/>. 
             </summary>
             <param name="connectionString">Connection parameters used for performing operations against shard map manager database(s).</param>
+            <param name="loadPolicy">Initialization policy.</param>
+            <returns>
+            A shard map manager object used for performing management and read operations for
+            shard maps, shards and shard mappings.
+            </returns>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.GetSqlShardMapManager(System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerLoadPolicy)">
+            <summary>
+            Gets <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager"/> from persisted state in a SQL Server database, with <see cref="P:Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior.DefaultRetryBehavior"/>. 
+            </summary>
+            <param name="connectionString">Connection parameters used for performing operations against shard map manager database(s).</param>
+            <param name="secureCredential">Secure credential used for performing operations against shard map manager database(s).</param>
             <param name="loadPolicy">Initialization policy.</param>
             <returns>
             A shard map manager object used for performing management and read operations for
@@ -12099,16 +12506,30 @@
             shard maps, shards and shard mappings.
             </returns>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.GetSqlShardMapManager(System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerLoadPolicy,Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior)">
+            <summary>
+            Gets <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager"/> from persisted state in a SQL Server database.
+            </summary>
+            <param name="connectionString">Connection parameters used for performing operations against shard map manager database(s).</param>
+            <param name="secureCredential">Secure credential used for performing operations against shard map manager database(s).</param>
+            <param name="loadPolicy">Initialization policy.</param>
+            <param name="retryBehavior">Behavior for detecting transient exceptions in the store.</param>
+            <returns>
+            A shard map manager object used for performing management and read operations for
+            shard maps, shards and shard mappings.
+            </returns>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.CreatePerformanceCategoryAndCounters">
             <summary>
             Create shard management performance counter category and counters
             </summary>
         </member>
-        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.GetSqlShardMapManager(System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerLoadPolicy,Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior,System.EventHandler{Microsoft.Azure.SqlDatabase.ElasticScale.RetryingEventArgs})">
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.GetSqlShardMapManager(System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerLoadPolicy,Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior,System.EventHandler{Microsoft.Azure.SqlDatabase.ElasticScale.RetryingEventArgs})">
             <summary>
             Gets <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager"/> from persisted state in a SQL Server database.
             </summary>
             <param name="connectionString">Connection parameters used for performing operations against shard map manager database(s).</param>
+            <param name="secureCredential">Secure credential used for performing operations against shard map manager database(s).</param>
             <param name="loadPolicy">Initialization policy.</param>
             <param name="retryBehavior">Behavior for detecting transient exceptions in the store.</param>
             <param name="retryEventHandler">Event handler for store operation retry events.</param>
@@ -12117,11 +12538,12 @@
             shard maps, shards and shard mappings.
             </returns>
         </member>
-        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.GetSqlShardMapManager(System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerLoadPolicy,Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior,System.EventHandler{Microsoft.Azure.SqlDatabase.ElasticScale.RetryingEventArgs},System.Boolean)">
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerFactory.GetSqlShardMapManager(System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManagerLoadPolicy,Microsoft.Azure.SqlDatabase.ElasticScale.RetryBehavior,System.EventHandler{Microsoft.Azure.SqlDatabase.ElasticScale.RetryingEventArgs},System.Boolean)">
             <summary>
             Gets <see cref="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapManager"/> from persisted state in a SQL Server database.
             </summary>
             <param name="connectionString">Connection parameters used for performing operations against shard map manager database(s).</param>
+            <param name="secureCredential">Secure credential used for performing operations against shard map manager database(s).</param>
             <param name="loadPolicy">Initialization policy.</param>
             <param name="retryBehavior">Behavior for detecting transient exceptions in the store.</param>
             <param name="retryEventHandler">Event handler for store operation retry events.</param>
@@ -13020,6 +13442,25 @@
             functionality in the Enterprise Library from Microsoft Patterns and Practices team.
             </remarks>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ListShardMap`1.OpenConnectionForKey(`0,System.String,System.Data.SqlClient.SqlCredential)">
+            <summary>
+            Opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the shard 
+            to which the specified key value is mapped, with <see cref="F:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions.Validate"/>.
+            </summary>
+            <param name="key">Input key value.</param>
+            <param name="connectionString">
+            Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+            The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure SQL Credential.</param>
+            <returns>An opened SqlConnection.</returns>
+            <remarks>
+            Note that the <see cref="T:System.Data.SqlClient.SqlConnection"/> object returned by this call is not protected against transient faults. 
+            Callers should follow best practices to protect the connection against transient faults 
+            in their application code, e.g., by using the transient fault handling 
+            functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+            </remarks>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ListShardMap`1.OpenConnectionForKey(`0,System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
             <summary>
             Opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the shard 
@@ -13030,6 +13471,26 @@
             Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
             The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
             </param>
+            <param name="options">Options for validation operations to perform on opened connection.</param>
+            <returns>An opened SqlConnection.</returns>
+            <remarks>
+            Note that the <see cref="T:System.Data.SqlClient.SqlConnection"/> object returned by this call is not protected against transient faults. 
+            Callers should follow best practices to protect the connection against transient faults 
+            in their application code, e.g., by using the transient fault handling 
+            functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ListShardMap`1.OpenConnectionForKey(`0,System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
+            <summary>
+            Opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the shard 
+            to which the specified key value is mapped.
+            </summary>
+            <param name="key">Input key value.</param>
+            <param name="connectionString">
+            Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+            The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure SQL Credential.</param>
             <param name="options">Options for validation operations to perform on opened connection.</param>
             <returns>An opened SqlConnection.</returns>
             <remarks>
@@ -13058,6 +13519,26 @@
             All non-usage error related exceptions are reported via the returned Task.
             </remarks>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ListShardMap`1.OpenConnectionForKeyAsync(`0,System.String,System.Data.SqlClient.SqlCredential)">
+            <summary>
+            Asynchronously opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the shard 
+            to which the specified key value is mapped, with <see cref="F:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions.Validate"/>.
+            </summary>
+            <param name="key">Input key value.</param>
+            <param name="connectionString">
+            Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+            The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure SQL Credential.</param>
+            <returns>A Task encapsulating an open SqlConnection as the result</returns>
+            <remarks>
+            Note that the <see cref="T:System.Data.SqlClient.SqlConnection"/> object returned by this call is not protected against transient faults. 
+            Callers should follow best practices to protect the connection against transient faults 
+            in their application code, e.g., by using the transient fault handling 
+            functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+            All non-usage error related exceptions are reported via the returned Task.
+            </remarks>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ListShardMap`1.OpenConnectionForKeyAsync(`0,System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
             <summary>
             Asynchronously opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the shard 
@@ -13068,6 +13549,27 @@
             Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
             The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
             </param>
+            <param name="options">Options for validation operations to perform on opened connection.</param>
+            <returns>A Task encapsulating an opened SqlConnection.</returns>
+            <remarks>
+            Note that the <see cref="T:System.Data.SqlClient.SqlConnection"/> object returned by this call is not protected against transient faults. 
+            Callers should follow best practices to protect the connection against transient faults 
+            in their application code, e.g., by using the transient fault handling 
+            functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+            All non-usage error related exceptions are reported via the returned Task.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ListShardMap`1.OpenConnectionForKeyAsync(`0,System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
+            <summary>
+            Asynchronously opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the shard 
+            to which the specified key value is mapped.
+            </summary>
+            <param name="key">Input key value.</param>
+            <param name="connectionString">
+            Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+            The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure SQL Credential.</param>
             <param name="options">Options for validation operations to perform on opened connection.</param>
             <returns>A Task encapsulating an opened SqlConnection.</returns>
             <remarks>
@@ -13277,6 +13779,25 @@
             functionality in the Enterprise Library from Microsoft Patterns and Practices team.
             </remarks>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeShardMap`1.OpenConnectionForKey(`0,System.String,System.Data.SqlClient.SqlCredential)">
+            <summary>
+            Opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the shard 
+            to which the specified key value is mapped, with <see cref="F:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions.Validate"/>.
+            </summary>
+            <param name="key">Input key value.</param>
+            <param name="connectionString">
+            Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+            The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure SQL Credential.</param>
+            <returns>An opened SqlConnection.</returns>
+            <remarks>
+            Note that the <see cref="T:System.Data.SqlClient.SqlConnection"/> object returned by this call is not protected against transient faults. 
+            Callers should follow best practices to protect the connection against transient faults 
+            in their application code, e.g., by using the transient fault handling 
+            functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+            </remarks>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeShardMap`1.OpenConnectionForKey(`0,System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
             <summary>
             Opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the shard 
@@ -13287,6 +13808,26 @@
             Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
             The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
             </param>
+            <param name="options">Options for validation operations to perform on opened connection.</param>
+            <returns>An opened SqlConnection.</returns>
+            <remarks>
+            Note that the <see cref="T:System.Data.SqlClient.SqlConnection"/> object returned by this call is not protected against transient faults. 
+            Callers should follow best practices to protect the connection against transient faults 
+            in their application code, e.g., by using the transient fault handling 
+            functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeShardMap`1.OpenConnectionForKey(`0,System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
+            <summary>
+            Opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the shard 
+            to which the specified key value is mapped.
+            </summary>
+            <param name="key">Input key value.</param>
+            <param name="connectionString">
+            Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+            The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure SQL Credential.</param>
             <param name="options">Options for validation operations to perform on opened connection.</param>
             <returns>An opened SqlConnection.</returns>
             <remarks>
@@ -13315,6 +13856,26 @@
             All non-usage errors will be propagated via the returned Task.
             </remarks>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeShardMap`1.OpenConnectionForKeyAsync(`0,System.String,System.Data.SqlClient.SqlCredential)">
+            <summary>
+            Asynchronously opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the shard 
+            to which the specified key value is mapped, with <see cref="F:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions.Validate"/>.
+            </summary>
+            <param name="key">Input key value.</param>
+            <param name="connectionString">
+            Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+            The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure SQL Credential.</param>
+            <returns>A Task encapsulating an opened SqlConnection.</returns>
+            <remarks>
+            Note that the <see cref="T:System.Data.SqlClient.SqlConnection"/> object returned by this call is not protected against transient faults. 
+            Callers should follow best practices to protect the connection against transient faults 
+            in their application code, e.g., by using the transient fault handling 
+            functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+            All non-usage errors will be propagated via the returned Task.
+            </remarks>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeShardMap`1.OpenConnectionForKeyAsync(`0,System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
             <summary>
             Asynchronously opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the shard 
@@ -13325,6 +13886,27 @@
             Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
             The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
             </param>
+            <param name="options">Options for validation operations to perform on opened connection.</param>
+            <returns>A Task encapsulating an opened SqlConnection.</returns>
+            <remarks>
+            Note that the <see cref="T:System.Data.SqlClient.SqlConnection"/> object returned by this call is not protected against transient faults. 
+            Callers should follow best practices to protect the connection against transient faults 
+            in their application code, e.g., by using the transient fault handling 
+            functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+            All non-usage errors will be propagated via the returned Task.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.RangeShardMap`1.OpenConnectionForKeyAsync(`0,System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
+            <summary>
+            Asynchronously opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the shard 
+            to which the specified key value is mapped.
+            </summary>
+            <param name="key">Input key value.</param>
+            <param name="connectionString">
+            Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+            The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure SQL Credential.</param>
             <param name="options">Options for validation operations to perform on opened connection.</param>
             <returns>A Task encapsulating an opened SqlConnection.</returns>
             <remarks>
@@ -13646,6 +14228,27 @@
             This call only works if there is a single default mapping.
             </remarks>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMap.OpenConnectionForKey``1(``0,System.String,System.Data.SqlClient.SqlCredential)">
+            <summary>
+            Opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the shard 
+            to which the specified key value is mapped, with <see cref="F:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions.Validate"/>.
+            </summary>
+            <typeparam name="TKey">Type of the key.</typeparam>
+            <param name="key">Input key value.</param>
+            <param name="connectionString">
+            Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+            The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure SQL Credential.</param>
+            <returns>An opened SqlConnection.</returns>
+            <remarks>
+            Note that the <see cref="T:System.Data.SqlClient.SqlConnection"/> object returned by this call is not protected against transient faults. 
+            Callers should follow best practices to protect the connection against transient faults 
+            in their application code, e.g., by using the transient fault handling 
+            functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+            This call only works if there is a single default mapping.
+            </remarks>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMap.OpenConnectionForKey``1(``0,System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
             <summary>
             Opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the shard 
@@ -13657,6 +14260,28 @@
             Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
             The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
             </param>
+            <param name="options">Options for validation operations to perform on opened connection.</param>
+            <returns>An opened SqlConnection.</returns>
+            <remarks>
+            Note that the <see cref="T:System.Data.SqlClient.SqlConnection"/> object returned by this call is not protected against transient faults. 
+            Callers should follow best practices to protect the connection against transient faults 
+            in their application code, e.g., by using the transient fault handling 
+            functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+            This call only works if there is a single default mapping.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMap.OpenConnectionForKey``1(``0,System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
+            <summary>
+            Opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the shard 
+            to which the specified key value is mapped.
+            </summary>
+            <typeparam name="TKey">Type of the key.</typeparam>
+            <param name="key">Input key value.</param>
+            <param name="connectionString">
+            Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+            The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure SQL Credential.</param>
             <param name="options">Options for validation operations to perform on opened connection.</param>
             <returns>An opened SqlConnection.</returns>
             <remarks>
@@ -13687,6 +14312,27 @@
             This call only works if there is a single default mapping.
             </remarks>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMap.OpenConnectionForKeyAsync``1(``0,System.String,System.Data.SqlClient.SqlCredential)">
+            <summary>
+            Asynchronously opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the shard 
+            to which the specified key value is mapped, with <see cref="F:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions.Validate"/>.
+            </summary>
+            <typeparam name="TKey">Type of the key.</typeparam>
+            <param name="key">Input key value.</param>
+            <param name="connectionString">
+            Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+            The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure SQL Credential.</param>
+            <returns>A Task encapsulating an opened SqlConnection.</returns>
+            <remarks>
+            Note that the <see cref="T:System.Data.SqlClient.SqlConnection"/> object returned by this call is not protected against transient faults. 
+            Callers should follow best practices to protect the connection against transient faults 
+            in their application code, e.g., by using the transient fault handling 
+            functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+            This call only works if there is a single default mapping.
+            </remarks>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMap.OpenConnectionForKeyAsync``1(``0,System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
             <summary>
             Asynchronously opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the shard 
@@ -13698,6 +14344,28 @@
             Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
             The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
             </param>
+            <param name="options">Options for validation operations to perform on opened connection.</param>
+            <returns>A Task encapsulating an opened SqlConnection.</returns>
+            <remarks>
+            Note that the <see cref="T:System.Data.SqlClient.SqlConnection"/> object returned by this call is not protected against transient faults. 
+            Callers should follow best practices to protect the connection against transient faults 
+            in their application code, e.g., by using the transient fault handling 
+            functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+            This call only works if there is a single default mapping.
+            </remarks>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMap.OpenConnectionForKeyAsync``1(``0,System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
+            <summary>
+            Asynchronously opens a regular <see cref="T:System.Data.SqlClient.SqlConnection"/> to the shard 
+            to which the specified key value is mapped.
+            </summary>
+            <typeparam name="TKey">Type of the key.</typeparam>
+            <param name="key">Input key value.</param>
+            <param name="connectionString">
+            Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+            The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+            </param>
+            <param name="secureCredential">Secure SQL Credential.</param>
             <param name="options">Options for validation operations to perform on opened connection.</param>
             <returns>A Task encapsulating an opened SqlConnection.</returns>
             <remarks>
@@ -13765,12 +14433,32 @@
             <param name="connectionString">Connection string for connection. Must have credentials.</param>
             <param name="options">Options for validation operations to perform on opened connection.</param>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMap.OpenConnection(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IShardProvider,System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
+            <summary>
+            Opens a connection to the given shard provider.
+            </summary>
+            <param name="shardProvider">Shard provider containing shard to be connected to.</param>
+            <param name="connectionString">Connection string for connection. Must have credentials.</param>
+            <param name="secureCredential">Secure SQL Credential.</param>
+            <param name="options">Options for validation operations to perform on opened connection.</param>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMap.OpenConnectionAsync(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IShardProvider,System.String,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
             <summary>
             Asynchronously opens a connection to the given shard provider.
             </summary>
             <param name="shardProvider">Shard provider containing shard to be connected to.</param>
             <param name="connectionString">Connection string for connection. Must have credentials.</param>
+            <param name="options">Options for validation operations to perform on opened connection.</param>
+            <returns>A task encapsulating the SqlConnection</returns>
+            <remarks>All exceptions are reported via the returned task.</remarks>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMap.OpenConnectionAsync(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IShardProvider,System.String,System.Data.SqlClient.SqlCredential,Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ConnectionOptions)">
+            <summary>
+            Asynchronously opens a connection to the given shard provider.
+            </summary>
+            <param name="shardProvider">Shard provider containing shard to be connected to.</param>
+            <param name="connectionString">Connection string for connection. Must have credentials.</param>
+            <param name="secureCredential">Secure Sql credential information.</param>
             <param name="options">Options for validation operations to perform on opened connection.</param>
             <returns>A task encapsulating the SqlConnection</returns>
             <remarks>All exceptions are reported via the returned task.</remarks>
@@ -13794,13 +14482,14 @@
             </summary>
             <returns>Cloned shard map instance.</returns>
         </member>
-        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMap.ValidateAndPrepareConnectionString(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IShardProvider,System.String)">
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMap.ValidateAndPrepareConnectionString(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IShardProvider,System.String,System.Data.SqlClient.SqlCredential)">
             <summary>
             Ensures that the provided connection string is valid and builds the connection string
             to be used for DDR connection to the given shard provider.
             </summary>
             <param name="shardProvider">Shard provider containing shard to be connected to.</param>
             <param name="connectionString">Input connection string.</param>
+            <param name="secureCredential"></param>
             <returns>Connection string for DDR connection.</returns>
         </member>
         <member name="T:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.ShardMapExtensions">
@@ -14102,6 +14791,15 @@
             Factory for store connections.
             </summary>
         </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreConnectionFactory.GetConnection(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreConnectionKind,System.String,System.Data.SqlClient.SqlCredential)">
+            <summary>
+            Constructs a new instance of store connection.
+            </summary>
+            <param name="kind">Type of store connection.</param>
+            <param name="connectionString">Connection string for store.</param>
+            <param name="secureCredential">Secure credential for store.</param>
+            <returns>An unopened instance of the store connection.</returns>
+        </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreConnectionFactory.GetConnection(Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.StoreConnectionKind,System.String)">
             <summary>
             Constructs a new instance of store connection.
@@ -14109,6 +14807,14 @@
             <param name="kind">Type of store connection.</param>
             <param name="connectionString">Connection string for store.</param>
             <returns>An unopened instance of the store connection.</returns>
+        </member>
+        <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreConnectionFactory.GetUserConnection(System.String,System.Data.SqlClient.SqlCredential)">
+            <summary>
+            Constructs a new instance of user connection.
+            </summary>
+            <param name="connectionString">Connection string of user.</param>
+            <param name="secureCredential">Secure credential of user.</param>
+            <returns>An unopened instance of the user connection.</returns>
         </member>
         <member name="M:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.IStoreConnectionFactory.GetUserConnection(System.String)">
             <summary>

--- a/Src/ElasticScale.Client/Microsoft.Azure.SqlDatabase.ElasticScale.Client.xml
+++ b/Src/ElasticScale.Client/Microsoft.Azure.SqlDatabase.ElasticScale.Client.xml
@@ -2334,7 +2334,7 @@
         </member>
         <member name="P:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.Errors._SqlShardMapManagerCredentials_ConnectionStringPropertyNotAllowed">
             <summary>
-              Looks up a localized string similar to The required property &apos;{0}&apos; must not be set in the connection string..
+              Looks up a localized string similar to The property &apos;{0}&apos; must not be set in the connection string..
             </summary>
         </member>
         <member name="P:Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.Errors._SqlShardMapManagerCredentials_ConnectionStringPropertyRequired">

--- a/Src/ElasticScale.Client/ShardManagement/Errors.Designer.cs
+++ b/Src/ElasticScale.Client/ShardManagement/Errors.Designer.cs
@@ -394,7 +394,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The required property &apos;{0}&apos; must not be set in the connection string..
+        ///   Looks up a localized string similar to The property &apos;{0}&apos; must not be set in the connection string..
         /// </summary>
         internal static string _SqlShardMapManagerCredentials_ConnectionStringPropertyNotAllowed {
             get {

--- a/Src/ElasticScale.Client/ShardManagement/Errors.Designer.cs
+++ b/Src/ElasticScale.Client/ShardManagement/Errors.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Errors {
@@ -390,6 +390,15 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement {
         internal static string _ShardRange_LowGreaterThanOrEqualToHigh {
             get {
                 return ResourceManager.GetString("_ShardRange_LowGreaterThanOrEqualToHigh", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The required property &apos;{0}&apos; must not be set in the connection string..
+        /// </summary>
+        internal static string _SqlShardMapManagerCredentials_ConnectionStringPropertyNotAllowed {
+            get {
+                return ResourceManager.GetString("_SqlShardMapManagerCredentials_ConnectionStringPropertyNotAllowed", resourceCulture);
             }
         }
         

--- a/Src/ElasticScale.Client/ShardManagement/Errors.resx
+++ b/Src/ElasticScale.Client/ShardManagement/Errors.resx
@@ -213,6 +213,9 @@
   <data name="_SqlShardMapManagerCredentials_ConnectionStringPropertyRequired" xml:space="preserve">
     <value>The required property '{0}' must be set in the connection string.</value>
   </data>
+  <data name="_SqlShardMapManagerCredentials_ConnectionStringPropertyNotAllowed" xml:space="preserve">
+    <value>The required property '{0}' must not be set in the connection string.</value>
+  </data>
   <data name="_Shard_DifferentShardMap" xml:space="preserve">
     <value>Shard '{0}' provided for the given '{1}' is not associated with current shard map '{2}'. The '{3}' operations required the shard to be associated with the current shard map.</value>
   </data>

--- a/Src/ElasticScale.Client/ShardManagement/Errors.resx
+++ b/Src/ElasticScale.Client/ShardManagement/Errors.resx
@@ -214,7 +214,7 @@
     <value>The required property '{0}' must be set in the connection string.</value>
   </data>
   <data name="_SqlShardMapManagerCredentials_ConnectionStringPropertyNotAllowed" xml:space="preserve">
-    <value>The required property '{0}' must not be set in the connection string.</value>
+    <value>The property '{0}' must not be set in the connection string.</value>
   </data>
   <data name="_Shard_DifferentShardMap" xml:space="preserve">
     <value>Shard '{0}' provided for the given '{1}' is not associated with current shard map '{2}'. The '{3}' operations required the shard to be associated with the current shard map.</value>

--- a/Src/ElasticScale.Client/ShardManagement/Shard/Shard.cs
+++ b/Src/ElasticScale.Client/ShardManagement/Shard/Shard.cs
@@ -251,7 +251,25 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// </remarks>
         public SqlConnection OpenConnection(string connectionString)
         {
-            return this.OpenConnection(connectionString, ConnectionOptions.Validate);
+            return this.OpenConnection(connectionString, null, ConnectionOptions.Validate);
+        }
+
+        /// <summary>
+        /// Opens a regular <see cref="SqlConnection"/> to the specified shard, with <see cref="ConnectionOptions.Validate"/>.
+        /// </summary>
+        /// <param name="connectionString">
+        /// Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+        /// The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure Sql credential information.</param>
+        /// <remarks>
+        /// Note that the <see cref="SqlConnection"/> object returned by this call is not protected against transient faults. 
+        /// Callers should follow best practices to protect the connection against transient faults in their application code, e.g., by using the transient fault handling 
+        /// functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+        /// </remarks>
+        public SqlConnection OpenConnection(string connectionString, SqlCredential secureCredential)
+        {
+            return this.OpenConnection(connectionString, secureCredential, ConnectionOptions.Validate);
         }
 
         /// <summary>
@@ -269,9 +287,28 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// </remarks>
         public SqlConnection OpenConnection(string connectionString, ConnectionOptions options)
         {
+            return this.OpenConnection(connectionString, null, options);
+        }
+
+        /// <summary>
+        /// Opens a regular <see cref="SqlConnection"/> to the specified shard.
+        /// </summary>
+        /// <param name="connectionString">
+        /// Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+        /// The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL credential information.</param>
+        /// <param name="options">Options for validation operations to perform on opened connection.</param>
+        /// <remarks>
+        /// Note that the <see cref="SqlConnection"/> object returned by this call is not protected against transient faults. 
+        /// Callers should follow best practices to protect the connection against transient faults in their application code, e.g., by using the transient fault handling 
+        /// functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+        /// </remarks>
+        public SqlConnection OpenConnection(string connectionString, SqlCredential secureCredential, ConnectionOptions options)
+        {
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                return this.ShardMap.OpenConnection(this as IShardProvider, connectionString, options);
+                return this.ShardMap.OpenConnection(this as IShardProvider, connectionString, secureCredential, options);
             }
         }
 
@@ -295,7 +332,27 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// </remarks>
         public Task<SqlConnection> OpenConnectionAsync(string connectionString)
         {
-            return this.OpenConnectionAsync(connectionString, ConnectionOptions.Validate);
+            return this.OpenConnectionAsync(connectionString, null, ConnectionOptions.Validate);
+        }
+
+        /// <summary>
+        /// Asynchronously opens a regular <see cref="SqlConnection"/> to the specified shard, with <see cref="ConnectionOptions.Validate"/>.
+        /// </summary>
+        /// <param name="connectionString">
+        /// Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+        /// The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        /// <returns>A Task encapsulating an opened SqlConnection</returns>
+        /// <remarks>
+        /// Note that the <see cref="SqlConnection"/> object returned by this call is not protected against transient faults. 
+        /// Callers should follow best practices to protect the connection against transient faults in their application code, e.g., by using the transient fault handling 
+        /// functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+        /// All non-usage errors will be propagated via the returned Task.
+        /// </remarks>
+        public Task<SqlConnection> OpenConnectionAsync(string connectionString, SqlCredential secureCredential)
+        {
+            return this.OpenConnectionAsync(connectionString, secureCredential, ConnectionOptions.Validate);
         }
 
         /// <summary>
@@ -315,9 +372,30 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// </remarks>
         public Task<SqlConnection> OpenConnectionAsync(string connectionString, ConnectionOptions options)
         {
+            return this.OpenConnectionAsync(connectionString, null, options);
+        }
+
+        /// <summary>
+        /// Asynchronously a regular <see cref="SqlConnection"/> to the specified shard.
+        /// </summary>
+        /// <param name="connectionString">
+        /// Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+        /// The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        /// <param name="options">Options for validation operations to perform on opened connection.</param>
+        /// <returns>A Task encapsulating an opened SqlConnection</returns>
+        /// <remarks>
+        /// Note that the <see cref="SqlConnection"/> object returned by this call is not protected against transient faults. 
+        /// Callers should follow best practices to protect the connection against transient faults in their application code, e.g., by using the transient fault handling 
+        /// functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+        /// All non-usage errors will be propagated via the returned Task.
+        /// </remarks>
+        public Task<SqlConnection> OpenConnectionAsync(string connectionString, SqlCredential secureCredential, ConnectionOptions options)
+        {
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                return this.ShardMap.OpenConnectionAsync(this as IShardProvider, connectionString, options);
+                return this.ShardMap.OpenConnectionAsync(this as IShardProvider, connectionString, secureCredential, options);
             }
         }
 

--- a/Src/ElasticScale.Client/ShardManagement/ShardMap/ListShardMap.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMap/ListShardMap.cs
@@ -59,6 +59,29 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
         /// <summary>
         /// Opens a regular <see cref="SqlConnection"/> to the shard 
+        /// to which the specified key value is mapped, with <see cref="ConnectionOptions.Validate"/>.
+        /// </summary>
+        /// <param name="key">Input key value.</param>
+        /// <param name="connectionString">
+        /// Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+        /// The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        /// <returns>An opened SqlConnection.</returns>
+        /// <remarks>
+        /// Note that the <see cref="SqlConnection"/> object returned by this call is not protected against transient faults. 
+        /// Callers should follow best practices to protect the connection against transient faults 
+        /// in their application code, e.g., by using the transient fault handling 
+        /// functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+        /// </remarks>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
+        public SqlConnection OpenConnectionForKey(TKey key, string connectionString, SqlCredential secureCredential)
+        {
+            return this.OpenConnectionForKey(key, connectionString, secureCredential, ConnectionOptions.Validate);
+        }
+
+        /// <summary>
+        /// Opens a regular <see cref="SqlConnection"/> to the shard 
         /// to which the specified key value is mapped.
         /// </summary>
         /// <param name="key">Input key value.</param>
@@ -77,11 +100,35 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
         public SqlConnection OpenConnectionForKey(TKey key, string connectionString, ConnectionOptions options)
         {
+            return this.OpenConnectionForKey(key, connectionString, null, options);
+        }
+
+        /// <summary>
+        /// Opens a regular <see cref="SqlConnection"/> to the shard 
+        /// to which the specified key value is mapped.
+        /// </summary>
+        /// <param name="key">Input key value.</param>
+        /// <param name="connectionString">
+        /// Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+        /// The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        /// <param name="options">Options for validation operations to perform on opened connection.</param>
+        /// <returns>An opened SqlConnection.</returns>
+        /// <remarks>
+        /// Note that the <see cref="SqlConnection"/> object returned by this call is not protected against transient faults. 
+        /// Callers should follow best practices to protect the connection against transient faults 
+        /// in their application code, e.g., by using the transient fault handling 
+        /// functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+        /// </remarks>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
+        public SqlConnection OpenConnectionForKey(TKey key, string connectionString, SqlCredential secureCredential, ConnectionOptions options)
+        {
             ExceptionUtils.DisallowNullArgument(connectionString, "connectionString");
 
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                return _lsm.OpenConnectionForKey(key, connectionString, options);
+                return _lsm.OpenConnectionForKey(key, connectionString, secureCredential, options);
             }
         }
 
@@ -114,6 +161,30 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
         /// <summary>
         /// Asynchronously opens a regular <see cref="SqlConnection"/> to the shard 
+        /// to which the specified key value is mapped, with <see cref="ConnectionOptions.Validate"/>.
+        /// </summary>
+        /// <param name="key">Input key value.</param>
+        /// <param name="connectionString">
+        /// Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+        /// The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        /// <returns>A Task encapsulating an open SqlConnection as the result</returns>
+        /// <remarks>
+        /// Note that the <see cref="SqlConnection"/> object returned by this call is not protected against transient faults. 
+        /// Callers should follow best practices to protect the connection against transient faults 
+        /// in their application code, e.g., by using the transient fault handling 
+        /// functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+        /// All non-usage error related exceptions are reported via the returned Task.
+        /// </remarks>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
+        public Task<SqlConnection> OpenConnectionForKeyAsync(TKey key, string connectionString, SqlCredential secureCredential)
+        {
+            return this.OpenConnectionForKeyAsync(key, connectionString, secureCredential, ConnectionOptions.Validate);
+        }
+
+        /// <summary>
+        /// Asynchronously opens a regular <see cref="SqlConnection"/> to the shard 
         /// to which the specified key value is mapped.
         /// </summary>
         /// <param name="key">Input key value.</param>
@@ -133,11 +204,36 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
         public Task<SqlConnection> OpenConnectionForKeyAsync(TKey key, string connectionString, ConnectionOptions options)
         {
+            return OpenConnectionForKeyAsync(key, connectionString, null, options);
+        }
+
+        /// <summary>
+        /// Asynchronously opens a regular <see cref="SqlConnection"/> to the shard 
+        /// to which the specified key value is mapped.
+        /// </summary>
+        /// <param name="key">Input key value.</param>
+        /// <param name="connectionString">
+        /// Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+        /// The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        /// <param name="options">Options for validation operations to perform on opened connection.</param>
+        /// <returns>A Task encapsulating an opened SqlConnection.</returns>
+        /// <remarks>
+        /// Note that the <see cref="SqlConnection"/> object returned by this call is not protected against transient faults. 
+        /// Callers should follow best practices to protect the connection against transient faults 
+        /// in their application code, e.g., by using the transient fault handling 
+        /// functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+        /// All non-usage error related exceptions are reported via the returned Task.
+        /// </remarks>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
+        public Task<SqlConnection> OpenConnectionForKeyAsync(TKey key, string connectionString, SqlCredential secureCredential, ConnectionOptions options)
+        {
             ExceptionUtils.DisallowNullArgument(connectionString, "connectionString");
 
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                return _lsm.OpenConnectionForKeyAsync(key, connectionString, options);
+                return _lsm.OpenConnectionForKeyAsync(key, connectionString, secureCredential, options);
             }
         }
 

--- a/Src/ElasticScale.Client/ShardManagement/ShardMap/RangeShardMap.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMap/RangeShardMap.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
@@ -59,6 +58,29 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
         /// <summary>
         /// Opens a regular <see cref="SqlConnection"/> to the shard 
+        /// to which the specified key value is mapped, with <see cref="ConnectionOptions.Validate"/>.
+        /// </summary>
+        /// <param name="key">Input key value.</param>
+        /// <param name="connectionString">
+        /// Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+        /// The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        /// <returns>An opened SqlConnection.</returns>
+        /// <remarks>
+        /// Note that the <see cref="SqlConnection"/> object returned by this call is not protected against transient faults. 
+        /// Callers should follow best practices to protect the connection against transient faults 
+        /// in their application code, e.g., by using the transient fault handling 
+        /// functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+        /// </remarks>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
+        public SqlConnection OpenConnectionForKey(TKey key, string connectionString, SqlCredential secureCredential)
+        {
+            return this.OpenConnectionForKey(key, connectionString, secureCredential, ConnectionOptions.Validate);
+        }
+
+        /// <summary>
+        /// Opens a regular <see cref="SqlConnection"/> to the shard 
         /// to which the specified key value is mapped.
         /// </summary>
         /// <param name="key">Input key value.</param>
@@ -77,11 +99,35 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
         public SqlConnection OpenConnectionForKey(TKey key, string connectionString, ConnectionOptions options)
         {
+            return this.OpenConnectionForKey(key, connectionString, null, options);
+        }
+
+        /// <summary>
+        /// Opens a regular <see cref="SqlConnection"/> to the shard 
+        /// to which the specified key value is mapped.
+        /// </summary>
+        /// <param name="key">Input key value.</param>
+        /// <param name="connectionString">
+        /// Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+        /// The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        /// <param name="options">Options for validation operations to perform on opened connection.</param>
+        /// <returns>An opened SqlConnection.</returns>
+        /// <remarks>
+        /// Note that the <see cref="SqlConnection"/> object returned by this call is not protected against transient faults. 
+        /// Callers should follow best practices to protect the connection against transient faults 
+        /// in their application code, e.g., by using the transient fault handling 
+        /// functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+        /// </remarks>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
+        public SqlConnection OpenConnectionForKey(TKey key, string connectionString, SqlCredential secureCredential, ConnectionOptions options)
+        {
             ExceptionUtils.DisallowNullArgument(connectionString, "connectionString");
 
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                return this.rsm.OpenConnectionForKey(key, connectionString, options);
+                return this.rsm.OpenConnectionForKey(key, connectionString, secureCredential, options);
             }
         }
 
@@ -114,6 +160,30 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
         /// <summary>
         /// Asynchronously opens a regular <see cref="SqlConnection"/> to the shard 
+        /// to which the specified key value is mapped, with <see cref="ConnectionOptions.Validate"/>.
+        /// </summary>
+        /// <param name="key">Input key value.</param>
+        /// <param name="connectionString">
+        /// Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+        /// The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        /// <returns>A Task encapsulating an opened SqlConnection.</returns>
+        /// <remarks>
+        /// Note that the <see cref="SqlConnection"/> object returned by this call is not protected against transient faults. 
+        /// Callers should follow best practices to protect the connection against transient faults 
+        /// in their application code, e.g., by using the transient fault handling 
+        /// functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+        /// All non-usage errors will be propagated via the returned Task.
+        /// </remarks>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
+        public Task<SqlConnection> OpenConnectionForKeyAsync(TKey key, string connectionString, SqlCredential secureCredential)
+        {
+            return this.OpenConnectionForKeyAsync(key, connectionString, secureCredential, ConnectionOptions.Validate);
+        }
+
+        /// <summary>
+        /// Asynchronously opens a regular <see cref="SqlConnection"/> to the shard 
         /// to which the specified key value is mapped.
         /// </summary>
         /// <param name="key">Input key value.</param>
@@ -133,11 +203,36 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
         public Task<SqlConnection> OpenConnectionForKeyAsync(TKey key, string connectionString, ConnectionOptions options)
         {
+            return OpenConnectionForKeyAsync(key, connectionString, null, options);
+        }
+
+        /// <summary>
+        /// Asynchronously opens a regular <see cref="SqlConnection"/> to the shard 
+        /// to which the specified key value is mapped.
+        /// </summary>
+        /// <param name="key">Input key value.</param>
+        /// <param name="connectionString">
+        /// Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+        /// The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        /// <param name="options">Options for validation operations to perform on opened connection.</param>
+        /// <returns>A Task encapsulating an opened SqlConnection.</returns>
+        /// <remarks>
+        /// Note that the <see cref="SqlConnection"/> object returned by this call is not protected against transient faults. 
+        /// Callers should follow best practices to protect the connection against transient faults 
+        /// in their application code, e.g., by using the transient fault handling 
+        /// functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+        /// All non-usage errors will be propagated via the returned Task.
+        /// </remarks>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1061:DoNotHideBaseClassMethods")]
+        public Task<SqlConnection> OpenConnectionForKeyAsync(TKey key, string connectionString, SqlCredential secureCredential, ConnectionOptions options)
+        {
             ExceptionUtils.DisallowNullArgument(connectionString, "connectionString");
 
             using (ActivityIdScope activityIdScope = new ActivityIdScope(Guid.NewGuid()))
             {
-                return this.rsm.OpenConnectionForKeyAsync(key, connectionString, options);
+                return this.rsm.OpenConnectionForKeyAsync(key, connectionString, secureCredential, options);
             }
         }
 

--- a/Src/ElasticScale.Client/ShardManagement/ShardMap/ShardMap.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMap/ShardMap.cs
@@ -150,6 +150,31 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
         /// <summary>
         /// Opens a regular <see cref="SqlConnection"/> to the shard 
+        /// to which the specified key value is mapped, with <see cref="ConnectionOptions.Validate"/>.
+        /// </summary>
+        /// <typeparam name="TKey">Type of the key.</typeparam>
+        /// <param name="key">Input key value.</param>
+        /// <param name="connectionString">
+        /// Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+        /// The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        /// <returns>An opened SqlConnection.</returns>
+        /// <remarks>
+        /// Note that the <see cref="SqlConnection"/> object returned by this call is not protected against transient faults. 
+        /// Callers should follow best practices to protect the connection against transient faults 
+        /// in their application code, e.g., by using the transient fault handling 
+        /// functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+        /// This call only works if there is a single default mapping.
+        /// </remarks>
+        public SqlConnection OpenConnectionForKey<TKey>(
+            TKey key, string connectionString, SqlCredential secureCredential)
+        {
+            return this.OpenConnectionForKey(key, connectionString, secureCredential, ConnectionOptions.Validate);
+        }
+
+        /// <summary>
+        /// Opens a regular <see cref="SqlConnection"/> to the shard 
         /// to which the specified key value is mapped.
         /// </summary>
         /// <typeparam name="TKey">Type of the key.</typeparam>
@@ -170,6 +195,35 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         public SqlConnection OpenConnectionForKey<TKey>(
             TKey key,
             string connectionString,
+            ConnectionOptions options)
+        {
+            return this.OpenConnectionForKey(key, connectionString, null, options);
+        }
+
+        /// <summary>
+        /// Opens a regular <see cref="SqlConnection"/> to the shard 
+        /// to which the specified key value is mapped.
+        /// </summary>
+        /// <typeparam name="TKey">Type of the key.</typeparam>
+        /// <param name="key">Input key value.</param>
+        /// <param name="connectionString">
+        /// Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+        /// The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        /// <param name="options">Options for validation operations to perform on opened connection.</param>
+        /// <returns>An opened SqlConnection.</returns>
+        /// <remarks>
+        /// Note that the <see cref="SqlConnection"/> object returned by this call is not protected against transient faults. 
+        /// Callers should follow best practices to protect the connection against transient faults 
+        /// in their application code, e.g., by using the transient fault handling 
+        /// functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+        /// This call only works if there is a single default mapping.
+        /// </remarks>
+        public SqlConnection OpenConnectionForKey<TKey>(
+            TKey key,
+            string connectionString,
+            SqlCredential secureCredential,
             ConnectionOptions options)
         {
             ExceptionUtils.DisallowNullArgument(connectionString, "connectionString");
@@ -193,7 +247,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
                 Debug.Assert(mapper != null);
 
-                return mapper.OpenConnectionForKey(key, connectionString, options);
+                return mapper.OpenConnectionForKey(key, connectionString, secureCredential, options);
             }
         }
 
@@ -223,6 +277,31 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
         /// <summary>
         /// Asynchronously opens a regular <see cref="SqlConnection"/> to the shard 
+        /// to which the specified key value is mapped, with <see cref="ConnectionOptions.Validate"/>.
+        /// </summary>
+        /// <typeparam name="TKey">Type of the key.</typeparam>
+        /// <param name="key">Input key value.</param>
+        /// <param name="connectionString">
+        /// Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+        /// The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        /// <returns>A Task encapsulating an opened SqlConnection.</returns>
+        /// <remarks>
+        /// Note that the <see cref="SqlConnection"/> object returned by this call is not protected against transient faults. 
+        /// Callers should follow best practices to protect the connection against transient faults 
+        /// in their application code, e.g., by using the transient fault handling 
+        /// functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+        /// This call only works if there is a single default mapping.
+        /// </remarks>
+        public Task<SqlConnection> OpenConnectionForKeyAsync<TKey>(
+            TKey key, string connectionString, SqlCredential secureCredential)
+        {
+            return this.OpenConnectionForKeyAsync(key, connectionString, secureCredential, ConnectionOptions.Validate);
+        }
+
+        /// <summary>
+        /// Asynchronously opens a regular <see cref="SqlConnection"/> to the shard 
         /// to which the specified key value is mapped.
         /// </summary>
         /// <typeparam name="TKey">Type of the key.</typeparam>
@@ -243,6 +322,35 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         public Task<SqlConnection> OpenConnectionForKeyAsync<TKey>(
             TKey key,
             string connectionString,
+            ConnectionOptions options)
+        {
+            return OpenConnectionForKeyAsync(key, connectionString, null, options);
+        }
+
+        /// <summary>
+        /// Asynchronously opens a regular <see cref="SqlConnection"/> to the shard 
+        /// to which the specified key value is mapped.
+        /// </summary>
+        /// <typeparam name="TKey">Type of the key.</typeparam>
+        /// <param name="key">Input key value.</param>
+        /// <param name="connectionString">
+        /// Connection string with credential information such as SQL Server credentials or Integrated Security settings. 
+        /// The hostname of the server and the database name for the shard are obtained from the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        /// <param name="options">Options for validation operations to perform on opened connection.</param>
+        /// <returns>A Task encapsulating an opened SqlConnection.</returns>
+        /// <remarks>
+        /// Note that the <see cref="SqlConnection"/> object returned by this call is not protected against transient faults. 
+        /// Callers should follow best practices to protect the connection against transient faults 
+        /// in their application code, e.g., by using the transient fault handling 
+        /// functionality in the Enterprise Library from Microsoft Patterns and Practices team.
+        /// This call only works if there is a single default mapping.
+        /// </remarks>
+        public Task<SqlConnection> OpenConnectionForKeyAsync<TKey>(
+            TKey key,
+            string connectionString,
+            SqlCredential secureCredential,
             ConnectionOptions options)
         {
             ExceptionUtils.DisallowNullArgument(connectionString, "connectionString");
@@ -266,7 +374,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
                 Debug.Assert(mapper != null);
 
-                return mapper.OpenConnectionForKeyAsync(key, connectionString, options);
+                return mapper.OpenConnectionForKeyAsync(key, connectionString, secureCredential, options);
             }
         }
 
@@ -531,10 +639,26 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <param name="shardProvider">Shard provider containing shard to be connected to.</param>
         /// <param name="connectionString">Connection string for connection. Must have credentials.</param>
         /// <param name="options">Options for validation operations to perform on opened connection.</param>
+        internal SqlConnection OpenConnection(
+            IShardProvider shardProvider,
+            string connectionString,
+            ConnectionOptions options = ConnectionOptions.Validate)
+        {
+            return this.OpenConnection(shardProvider, connectionString, null, options);
+        }
+
+        /// <summary>
+        /// Opens a connection to the given shard provider.
+        /// </summary>
+        /// <param name="shardProvider">Shard provider containing shard to be connected to.</param>
+        /// <param name="connectionString">Connection string for connection. Must have credentials.</param>
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        /// <param name="options">Options for validation operations to perform on opened connection.</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Caller will be responsible for disposal")]
         internal SqlConnection OpenConnection(
             IShardProvider shardProvider,
             string connectionString,
+            SqlCredential secureCredential,
             ConnectionOptions options = ConnectionOptions.Validate)
         {
             Debug.Assert(shardProvider != null, "Expecting IShardProvider.");
@@ -542,7 +666,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             string connectionStringFinal = this.ValidateAndPrepareConnectionString(
                 shardProvider,
-                connectionString);
+                connectionString,
+                secureCredential);
 
             ExceptionUtils.EnsureShardBelongsToShardMap(
                 this.Manager,
@@ -551,7 +676,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 "OpenConnection",
                 "Shard");
 
-            IUserStoreConnection conn = this.Manager.StoreConnectionFactory.GetUserConnection(connectionStringFinal);
+            IUserStoreConnection conn = this.Manager.StoreConnectionFactory.GetUserConnection(connectionStringFinal, secureCredential);
 
             Tracer.TraceInfo(
                 TraceSourceConstants.ComponentNames.ShardMap,
@@ -595,10 +720,32 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <param name="options">Options for validation operations to perform on opened connection.</param>
         /// <returns>A task encapsulating the SqlConnection</returns>
         /// <remarks>All exceptions are reported via the returned task.</remarks>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "Microsoft.Reliability",
+            "CA2000:Dispose objects before losing scope",
+            Justification = "Caller will be responsible for disposal")]
+        internal async Task<SqlConnection> OpenConnectionAsync(
+            IShardProvider shardProvider,
+            string connectionString,
+            ConnectionOptions options = ConnectionOptions.Validate)
+        {
+            return await this.OpenConnectionAsync(shardProvider, connectionString, null, options);
+        }
+
+        /// <summary>
+        /// Asynchronously opens a connection to the given shard provider.
+        /// </summary>
+        /// <param name="shardProvider">Shard provider containing shard to be connected to.</param>
+        /// <param name="connectionString">Connection string for connection. Must have credentials.</param>
+        /// <param name="secureCredential">Secure Sql credential information.</param>
+        /// <param name="options">Options for validation operations to perform on opened connection.</param>
+        /// <returns>A task encapsulating the SqlConnection</returns>
+        /// <remarks>All exceptions are reported via the returned task.</remarks>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Caller will be responsible for disposal")]
         internal async Task<SqlConnection> OpenConnectionAsync(
             IShardProvider shardProvider,
             string connectionString,
+            SqlCredential secureCredential,
             ConnectionOptions options = ConnectionOptions.Validate)
         {
             Debug.Assert(shardProvider != null, "Expecting IShardProvider.");
@@ -606,7 +753,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
             string connectionStringFinal = this.ValidateAndPrepareConnectionString(
                 shardProvider,
-                connectionString);
+                connectionString,
+                secureCredential);
 
             ExceptionUtils.EnsureShardBelongsToShardMap(
                 this.Manager,
@@ -615,7 +763,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 "OpenConnectionAsync",
                 "Shard");
 
-            IUserStoreConnection conn = this.Manager.StoreConnectionFactory.GetUserConnection(connectionStringFinal);
+            IUserStoreConnection conn = this.Manager.StoreConnectionFactory.GetUserConnection(connectionStringFinal, secureCredential);
 
             Tracer.TraceInfo(
                 TraceSourceConstants.ComponentNames.ShardMap,
@@ -683,8 +831,12 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// </summary>
         /// <param name="shardProvider">Shard provider containing shard to be connected to.</param>
         /// <param name="connectionString">Input connection string.</param>
+        /// <param name="secureCredential"></param>
         /// <returns>Connection string for DDR connection.</returns>
-        private string ValidateAndPrepareConnectionString(IShardProvider shardProvider, string connectionString)
+        private string ValidateAndPrepareConnectionString(
+            IShardProvider shardProvider,
+            string connectionString,
+            SqlCredential secureCredential)
         {
             Debug.Assert(shardProvider != null);
             Debug.Assert(connectionString != null);
@@ -724,7 +876,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             }
 
             // Verify that either UserID/Password or provided or integrated authentication is enabled.
-            SqlShardMapManagerCredentials.EnsureCredentials(connectionStringBuilder, "connectionString");
+            SqlShardMapManagerCredentials.EnsureCredentials(connectionStringBuilder, "connectionString", secureCredential);
 
             Shard s = shardProvider.ShardInfo;
 

--- a/Src/ElasticScale.Client/ShardManagement/ShardMapManager/ShardMapManagerFactory.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMapManager/ShardMapManagerFactory.cs
@@ -76,6 +76,27 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             return CreateSqlShardMapManager(
                 connectionString,
+                secureCredential: null);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ShardMapManager"/> and its corresponding storage structures in the specified SQL Server database,
+        /// with <see cref="ShardMapManagerCreateMode.KeepExisting"/> and <see cref="RetryBehavior.DefaultRetryBehavior"/>.
+        /// </summary>
+        /// <param name="connectionString">Connection parameters used for creating shard map manager database.</param>
+        /// <param name="secureCredential">Secure credential used for creating shard map manager database.</param>
+        /// <returns>
+        /// A shard map manager object used for performing management and read operations for
+        /// shard maps, shards and shard mappings.
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0")]
+        public static ShardMapManager CreateSqlShardMapManager(
+            string connectionString,
+            SqlCredential secureCredential)
+        {
+            return CreateSqlShardMapManager(
+                connectionString,
+                secureCredential,
                 ShardMapManagerCreateMode.KeepExisting,
                 RetryBehavior.DefaultRetryBehavior);
         }
@@ -97,10 +118,33 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             return CreateSqlShardMapManager(
                 connectionString,
+                null,
+                createMode);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ShardMapManager"/> and its corresponding storage structures in the specified SQL Server database, 
+        /// with <see cref="RetryBehavior.DefaultRetryBehavior"/>.
+        /// </summary>
+        /// <param name="connectionString">Connection parameters used for creating shard map manager database.</param>
+        /// <param name="secureCredential">Secure credential used for creating shard map manager database.</param>
+        /// <param name="createMode">Describes the option selected by the user for creating shard map manager database.</param>
+        /// <returns>
+        /// A shard map manager object used for performing management and read operations for
+        /// shard maps, shards and shard mappings.
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0")]
+        public static ShardMapManager CreateSqlShardMapManager(
+            string connectionString,
+            SqlCredential secureCredential,
+            ShardMapManagerCreateMode createMode)
+        {
+            return CreateSqlShardMapManager(
+                connectionString,
+                secureCredential,
                 createMode,
                 RetryBehavior.DefaultRetryBehavior);
         }
-
 
         /// <summary>
         /// Creates a <see cref="ShardMapManager"/> and its corresponding storage structures in the specified SQL Server database, 
@@ -115,8 +159,31 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             ShardMapManagerCreateMode createMode,
             Version targetVersion)
         {
+            return CreateSqlShardMapManager(
+                connectionString,
+                null,
+                createMode,
+                targetVersion);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ShardMapManager"/> and its corresponding storage structures in the specified SQL Server database, 
+        /// with <see cref="RetryPolicy.DefaultRetryPolicy"/>.
+        /// </summary>
+        /// <param name="connectionString">Connection parameters used for creating shard map manager database.</param>
+        /// <param name="secureCredential">Secure credential used for creating shard map manager database.</param>
+        /// <param name="createMode">Describes the option selected by the user for creating shard map manager database.</param>
+        /// <param name="targetVersion">Target version of store to create.</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0")]
+        internal static ShardMapManager CreateSqlShardMapManager(
+            string connectionString,
+            SqlCredential secureCredential,
+            ShardMapManagerCreateMode createMode,
+            Version targetVersion)
+        {
             return CreateSqlShardMapManagerImpl(
                 connectionString,
+                secureCredential,
                 createMode,
                 RetryBehavior.DefaultRetryBehavior,
                 null,
@@ -140,6 +207,30 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             return CreateSqlShardMapManager(
                 connectionString,
+                null,
+                retryBehavior);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ShardMapManager"/> and its corresponding storage structures in the specified SQL Server database,
+        /// with <see cref="ShardMapManagerCreateMode.KeepExisting"/>.
+        /// </summary>
+        /// <param name="connectionString">Connection parameters used for creating shard map manager database.</param>
+        /// <param name="secureCredential">Secure credential used for creating shard map manager database.</param>
+        /// <param name="retryBehavior">Behavior for detecting transient exceptions in the store.</param>
+        /// <returns>
+        /// A shard map manager object used for performing management and read operations for
+        /// shard maps, shards and shard mappings.
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0")]
+        public static ShardMapManager CreateSqlShardMapManager(
+            string connectionString,
+            SqlCredential secureCredential,
+            RetryBehavior retryBehavior)
+        {
+            return CreateSqlShardMapManager(
+                connectionString,
+                secureCredential,
                 ShardMapManagerCreateMode.KeepExisting,
                 retryBehavior);
         }
@@ -156,14 +247,42 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// </returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope"),
          System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0"),
-        System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "2")]
+         System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "2")]
         public static ShardMapManager CreateSqlShardMapManager(
             string connectionString,
             ShardMapManagerCreateMode createMode,
             RetryBehavior retryBehavior)
         {
+            return CreateSqlShardMapManager(
+                connectionString,
+                null,
+                createMode,
+                retryBehavior);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ShardMapManager"/> and its corresponding storage structures in the specified SQL Server database.
+        /// </summary>
+        /// <param name="connectionString">Connection parameters used for creating shard map manager database.</param>
+        /// <param name="secureCredential">Secure credential used for creating shard map manager database.</param>
+        /// <param name="createMode">Describes the option selected by the user for creating shard map manager database.</param>
+        /// <param name="retryBehavior">Behavior for detecting transient exceptions in the store.</param>
+        /// <returns>
+        /// A shard map manager object used for performing management and read operations for
+        /// shard maps, shards and shard mappings.
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope"),
+         System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0"),
+        System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "2")]
+        public static ShardMapManager CreateSqlShardMapManager(
+            string connectionString,
+            SqlCredential secureCredential,
+            ShardMapManagerCreateMode createMode,
+            RetryBehavior retryBehavior)
+        {
             return CreateSqlShardMapManagerImpl(
                 connectionString,
+                secureCredential,
                 createMode,
                 retryBehavior,
                 null,
@@ -183,15 +302,46 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// </returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope"),
          System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0"),
-        System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "2")]
+         System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "2")]
         internal static ShardMapManager CreateSqlShardMapManager(
             string connectionString,
             ShardMapManagerCreateMode createMode,
             RetryBehavior retryBehavior,
             EventHandler<RetryingEventArgs> retryEventHandler)
         {
+            return CreateSqlShardMapManager(
+                connectionString,
+                null,
+                createMode,
+                retryBehavior,
+                retryEventHandler);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ShardMapManager"/> and its corresponding storage structures in the specified SQL Server database.
+        /// </summary>
+        /// <param name="connectionString">Connection parameters used for creating shard map manager database.</param>
+        /// <param name="secureCredential">Secure credential used for creating shard map manager database.</param>
+        /// <param name="createMode">Describes the option selected by the user for creating shard map manager database.</param>
+        /// <param name="retryBehavior">Behavior for detecting transient exceptions in the store.</param>
+        /// <param name="retryEventHandler">Event handler for store operation retry events.</param>
+        /// <returns>
+        /// A shard map manager object used for performing management and read operations for
+        /// shard maps, shards and shard mappings.
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope"),
+         System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0"),
+        System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "2")]
+        internal static ShardMapManager CreateSqlShardMapManager(
+            string connectionString,
+            SqlCredential secureCredential,
+            ShardMapManagerCreateMode createMode,
+            RetryBehavior retryBehavior,
+            EventHandler<RetryingEventArgs> retryEventHandler)
+        {
             return CreateSqlShardMapManagerImpl(
                 connectionString,
+                secureCredential,
                 createMode,
                 retryBehavior,
                 retryEventHandler,
@@ -202,10 +352,11 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// Creates a <see cref="ShardMapManager"/> and its corresponding storage structures in the specified SQL Server database.
         /// </summary>
         /// <param name="connectionString">Connection parameters used for creating shard map manager database.</param>
+        /// <param name="secureCredential">Secure credential used for creating shard map manager database.</param>
         /// <param name="createMode">Describes the option selected by the user for creating shard map manager database.</param>
         /// <param name="retryBehavior">Behavior for performing retries on connections to shard map manager database.</param>
-        /// <param name="targetVersion">Target version of Store to deploy, this is mainly used for upgrade testing.</param>
         /// <param name="retryEventHandler">Event handler for store operation retry events.</param>
+        /// <param name="targetVersion">Target version of Store to deploy, this is mainly used for upgrade testing.</param>
         /// <returns>
         /// A shard map manager object used for performing management and read operations for
         /// shard maps, shards and shard mappings.
@@ -215,6 +366,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
          System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "2")]
         private static ShardMapManager CreateSqlShardMapManagerImpl(
             string connectionString,
+            SqlCredential secureCredential,
             ShardMapManagerCreateMode createMode,
             RetryBehavior retryBehavior,
             EventHandler<RetryingEventArgs> retryEventHandler,
@@ -243,7 +395,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
                 Stopwatch stopwatch = Stopwatch.StartNew();
 
-                SqlShardMapManagerCredentials credentials = new SqlShardMapManagerCredentials(connectionString);
+                SqlShardMapManagerCredentials credentials = new SqlShardMapManagerCredentials(connectionString, secureCredential);
 
                 TransientFaultHandling.RetryPolicy retryPolicy = new TransientFaultHandling.RetryPolicy(
                         new ShardManagementTransientErrorDetectionStrategy(retryBehavior),
@@ -316,6 +468,33 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             return TryGetSqlShardMapManager(
                 connectionString,
+                null,
+                loadPolicy,
+                out shardMapManager);
+        }
+
+        /// <summary>
+        /// Gets <see cref="ShardMapManager"/> from persisted state in a SQL Server database.
+        /// </summary>
+        /// <param name="connectionString">Connection parameters used for performing operations against shard map manager database(s).</param>
+        /// <param name="secureCredential">Secure credential used for performing operations against shard map manager database(s).</param>
+        /// <param name="loadPolicy">Initialization policy.</param>
+        /// <param name="shardMapManager">Shard map manager object used for performing management and read operations for shard maps, 
+        ///     shards and shard mappings or <c>null</c> in case shard map manager does not exist.</param>
+        /// <returns>
+        /// <c>true</c> if a shard map manager object was created, <c>false</c> otherwise.
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "2#")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0")]
+        public static bool TryGetSqlShardMapManager(
+            string connectionString,
+            SqlCredential secureCredential,
+            ShardMapManagerLoadPolicy loadPolicy,
+            out ShardMapManager shardMapManager)
+        {
+            return TryGetSqlShardMapManager(
+                connectionString,
+                secureCredential,
                 loadPolicy,
                 RetryBehavior.DefaultRetryBehavior,
                 out shardMapManager);
@@ -326,9 +505,9 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// </summary>
         /// <param name="connectionString">Connection parameters used for performing operations against shard map manager database(s).</param>
         /// <param name="loadPolicy">Initialization policy.</param>
-        /// <param name="shardMapManager">Shard map manager object used for performing management and read operations for shard maps, 
-        /// shards and shard mappings or <c>null</c> in case shard map manager does not exist.</param>
         /// <param name="retryBehavior">Behavior for detecting transient exceptions in the store.</param>
+        /// <param name="shardMapManager">Shard map manager object used for performing management and read operations for shard maps, 
+        ///     shards and shard mappings or <c>null</c> in case shard map manager does not exist.</param>
         /// <returns>
         /// <c>true</c> if a shard map manager object was created, <c>false</c> otherwise.
         /// </returns>
@@ -337,6 +516,36 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
          System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "2")]
         public static bool TryGetSqlShardMapManager(
             string connectionString,
+            ShardMapManagerLoadPolicy loadPolicy,
+            RetryBehavior retryBehavior,
+            out ShardMapManager shardMapManager)
+        {
+            return TryGetSqlShardMapManager(
+                    connectionString,
+                    null,
+                    loadPolicy,
+                    retryBehavior,
+                    out shardMapManager);
+        }
+
+        /// <summary>
+        /// Gets <see cref="ShardMapManager"/> from persisted state in a SQL Server database.
+        /// </summary>
+        /// <param name="connectionString">Connection parameters used for performing operations against shard map manager database(s).</param>
+        /// <param name="secureCredential">Secure credential used for performing operations against shard map manager database(s).</param>
+        /// <param name="loadPolicy">Initialization policy.</param>
+        /// <param name="retryBehavior">Behavior for detecting transient exceptions in the store.</param>
+        /// <param name="shardMapManager">Shard map manager object used for performing management and read operations for shard maps, 
+        ///     shards and shard mappings or <c>null</c> in case shard map manager does not exist.</param>
+        /// <returns>
+        /// <c>true</c> if a shard map manager object was created, <c>false</c> otherwise.
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "2#"),
+         System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0"),
+         System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "2")]
+        public static bool TryGetSqlShardMapManager(
+            string connectionString,
+            SqlCredential secureCredential,
             ShardMapManagerLoadPolicy loadPolicy,
             RetryBehavior retryBehavior,
             out ShardMapManager shardMapManager)
@@ -355,6 +564,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
                 shardMapManager = ShardMapManagerFactory.GetSqlShardMapManager(
                     connectionString,
+                    secureCredential,
                     loadPolicy,
                     retryBehavior,
                     null,
@@ -376,11 +586,12 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// Gets <see cref="ShardMapManager"/> from persisted state in a SQL Server database.
         /// </summary>
         /// <param name="connectionString">Connection parameters used for performing operations against shard map manager database(s).</param>
+        /// <param name="secureCredential">Secure credential used for performing operations against shard map manager database(s).</param>
         /// <param name="loadPolicy">Initialization policy.</param>
-        /// <param name="shardMapManager">Shard map manager object used for performing management and read operations for shard maps, 
-        /// shards and shard mappings or <c>null</c> in case shard map manager does not exist.</param>
         /// <param name="retryBehavior">Behavior for detecting transient exceptions in the store.</param>
         /// <param name="retryEventHandler">Event handler for store operation retry events.</param>
+        /// <param name="shardMapManager">Shard map manager object used for performing management and read operations for shard maps, 
+        ///     shards and shard mappings or <c>null</c> in case shard map manager does not exist.</param>
         /// <returns>
         /// <c>true</c> if a shard map manager object was created, <c>false</c> otherwise.
         /// </returns>
@@ -389,6 +600,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
          System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "2")]
         internal static bool TryGetSqlShardMapManager(
             string connectionString,
+            SqlCredential secureCredential,
             ShardMapManagerLoadPolicy loadPolicy,
             RetryBehavior retryBehavior,
             EventHandler<RetryingEventArgs> retryEventHandler,
@@ -408,6 +620,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
                 shardMapManager = ShardMapManagerFactory.GetSqlShardMapManager(
                     connectionString,
+                    secureCredential,
                     loadPolicy,
                     retryBehavior,
                     retryEventHandler,
@@ -441,6 +654,30 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             return GetSqlShardMapManager(
                 connectionString,
+                null,
+                loadPolicy,
+                RetryBehavior.DefaultRetryBehavior);
+        }
+
+        /// <summary>
+        /// Gets <see cref="ShardMapManager"/> from persisted state in a SQL Server database, with <see cref="RetryBehavior.DefaultRetryBehavior"/>. 
+        /// </summary>
+        /// <param name="connectionString">Connection parameters used for performing operations against shard map manager database(s).</param>
+        /// <param name="secureCredential">Secure credential used for performing operations against shard map manager database(s).</param>
+        /// <param name="loadPolicy">Initialization policy.</param>
+        /// <returns>
+        /// A shard map manager object used for performing management and read operations for
+        /// shard maps, shards and shard mappings.
+        /// </returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0")]
+        public static ShardMapManager GetSqlShardMapManager(
+            string connectionString,
+            SqlCredential secureCredential,
+            ShardMapManagerLoadPolicy loadPolicy)
+        {
+            return GetSqlShardMapManager(
+                connectionString,
+                secureCredential,
                 loadPolicy,
                 RetryBehavior.DefaultRetryBehavior);
         }
@@ -462,6 +699,32 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         {
             return GetSqlShardMapManager(
                 connectionString,
+                null,
+                loadPolicy,
+                retryBehavior,
+                null);
+        }
+
+        /// <summary>
+        /// Gets <see cref="ShardMapManager"/> from persisted state in a SQL Server database.
+        /// </summary>
+        /// <param name="connectionString">Connection parameters used for performing operations against shard map manager database(s).</param>
+        /// <param name="secureCredential">Secure credential used for performing operations against shard map manager database(s).</param>
+        /// <param name="loadPolicy">Initialization policy.</param>
+        /// <param name="retryBehavior">Behavior for detecting transient exceptions in the store.</param>
+        /// <returns>
+        /// A shard map manager object used for performing management and read operations for
+        /// shard maps, shards and shard mappings.
+        /// </returns>
+        public static ShardMapManager GetSqlShardMapManager(
+            string connectionString,
+            SqlCredential secureCredential,
+            ShardMapManagerLoadPolicy loadPolicy,
+            RetryBehavior retryBehavior)
+        {
+            return GetSqlShardMapManager(
+                connectionString,
+                secureCredential,
                 loadPolicy,
                 retryBehavior,
                 null);
@@ -479,6 +742,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// Gets <see cref="ShardMapManager"/> from persisted state in a SQL Server database.
         /// </summary>
         /// <param name="connectionString">Connection parameters used for performing operations against shard map manager database(s).</param>
+        /// <param name="secureCredential">Secure credential used for performing operations against shard map manager database(s).</param>
         /// <param name="loadPolicy">Initialization policy.</param>
         /// <param name="retryBehavior">Behavior for detecting transient exceptions in the store.</param>
         /// <param name="retryEventHandler">Event handler for store operation retry events.</param>
@@ -489,6 +753,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0")]
         internal static ShardMapManager GetSqlShardMapManager(
             string connectionString,
+            SqlCredential secureCredential,
             ShardMapManagerLoadPolicy loadPolicy,
             RetryBehavior retryBehavior,
             EventHandler<RetryingEventArgs> retryEventHandler)
@@ -507,6 +772,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
                 ShardMapManager shardMapManager = ShardMapManagerFactory.GetSqlShardMapManager(
                     connectionString,
+                    secureCredential,
                     loadPolicy,
                     retryBehavior,
                     retryEventHandler,
@@ -530,6 +796,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// Gets <see cref="ShardMapManager"/> from persisted state in a SQL Server database.
         /// </summary>
         /// <param name="connectionString">Connection parameters used for performing operations against shard map manager database(s).</param>
+        /// <param name="secureCredential">Secure credential used for performing operations against shard map manager database(s).</param>
         /// <param name="loadPolicy">Initialization policy.</param>
         /// <param name="retryBehavior">Behavior for detecting transient exceptions in the store.</param>
         /// <param name="retryEventHandler">Event handler for store operation retry events.</param>
@@ -541,6 +808,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "We need to hand of the ShardMapManager to the user.")]
         private static ShardMapManager GetSqlShardMapManager(
             string connectionString,
+            SqlCredential secureCredential,
             ShardMapManagerLoadPolicy loadPolicy,
             RetryBehavior retryBehavior,
             EventHandler<RetryingEventArgs> retryEventHandler,
@@ -549,7 +817,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             Debug.Assert(connectionString != null);
             Debug.Assert(retryBehavior != null);
 
-            SqlShardMapManagerCredentials credentials = new SqlShardMapManagerCredentials(connectionString);
+            SqlShardMapManagerCredentials credentials = new SqlShardMapManagerCredentials(connectionString, secureCredential);
 
             StoreOperationFactory storeOperationFactory = new StoreOperationFactory();
 

--- a/Src/ElasticScale.Client/ShardManagement/ShardMapper/DefaultShardMapper.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMapper/DefaultShardMapper.cs
@@ -39,10 +39,30 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             string connectionString,
             ConnectionOptions options = ConnectionOptions.Validate)
         {
+            return this.OpenConnectionForKey(key, connectionString, null, options);
+        }
+
+        /// <summary>
+        /// Given a shard, obtains a SqlConnection to the shard. The shard must exist in the mapper.
+        /// </summary>
+        /// <param name="key">Input shard.</param>
+        /// <param name="connectionString">
+        /// Connection string with credential information, the DataSource and Database are 
+        /// obtained from the results of the lookup operation.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL credential.</param>
+        /// <param name="options">Options for validation operations to perform on opened connection.</param>
+        /// <returns>An opened SqlConnection.</returns>
+        public SqlConnection OpenConnectionForKey(
+            Shard key,
+            string connectionString,
+            SqlCredential secureCredential,
+            ConnectionOptions options = ConnectionOptions.Validate)
+        {
             Debug.Assert(key != null);
             Debug.Assert(connectionString != null);
 
-            return this.ShardMap.OpenConnection(this.Lookup(key, true), connectionString, options);
+            return this.ShardMap.OpenConnection(this.Lookup(key, true), connectionString, secureCredential, options);
         }
 
         /// <summary>
@@ -60,10 +80,30 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             string connectionString,
             ConnectionOptions options = ConnectionOptions.Validate)
         {
+            return await this.OpenConnectionForKeyAsync(key, connectionString, null, options);
+        }
+
+        /// <summary>
+        /// Given a shard, asynchronously obtains a SqlConnection to the shard. The shard must exist in the mapper.
+        /// </summary>
+        /// <param name="key">Input shard.</param>
+        /// <param name="connectionString">
+        /// Connection string with credential information, the DataSource and Database are 
+        /// obtained from the results of the lookup operation.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL credential.</param>
+        /// <param name="options">Options for validation operations to perform on opened connection.</param>
+        /// <returns>An opened SqlConnection.</returns>
+        public async Task<SqlConnection> OpenConnectionForKeyAsync(
+            Shard key,
+            string connectionString,
+            SqlCredential secureCredential,
+            ConnectionOptions options = ConnectionOptions.Validate)
+        {
             Debug.Assert(key != null);
             Debug.Assert(connectionString != null);
 
-            return await this.ShardMap.OpenConnectionAsync(this.Lookup(key, true), connectionString, options).ConfigureAwait(false);
+            return await this.ShardMap.OpenConnectionAsync(this.Lookup(key, true), connectionString, secureCredential, options).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Src/ElasticScale.Client/ShardManagement/ShardMapper/IShardMapper.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMapper/IShardMapper.cs
@@ -76,6 +76,20 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         SqlConnection OpenConnectionForKey(TKey key, string connectionString, ConnectionOptions options = ConnectionOptions.Validate);
 
         /// <summary>
+        /// Given a key value, obtains a SqlConnection to the shard in the mapping
+        /// that contains the key value.
+        /// </summary>
+        /// <param name="key">Input key value.</param>
+        /// <param name="connectionString">
+        /// Connection string with credential information, the DataSource and Database are 
+        /// obtained from the results of the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        /// <param name="options">Options for validation operations to perform on opened connection.</param>
+        /// <returns>An opened SqlConnection.</returns>
+        SqlConnection OpenConnectionForKey(TKey key, string connectionString, SqlCredential secureCredential, ConnectionOptions options = ConnectionOptions.Validate);
+
+        /// <summary>
         /// Given a key value, asynchronously obtains a SqlConnection to the shard in the mapping
         /// that contains the key value.
         /// </summary>
@@ -87,6 +101,20 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <param name="options">Options for validation operations to perform on opened connection.</param>
         /// <returns>An opened SqlConnection.</returns>
         Task<SqlConnection> OpenConnectionForKeyAsync(TKey key, string connectionString, ConnectionOptions options = ConnectionOptions.Validate);
+
+        /// <summary>
+        /// Given a key value, asynchronously obtains a SqlConnection to the shard in the mapping
+        /// that contains the key value.
+        /// </summary>
+        /// <param name="key">Input key value.</param>
+        /// <param name="connectionString">
+        /// Connection string with credential information, the DataSource and Database are 
+        /// obtained from the results of the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        /// <param name="options">Options for validation operations to perform on opened connection.</param>
+        /// <returns>An opened SqlConnection.</returns>
+        Task<SqlConnection> OpenConnectionForKeyAsync(TKey key, string connectionString, SqlCredential secureCredential, ConnectionOptions options = ConnectionOptions.Validate);
     }
 
     /// <summary>

--- a/Src/ElasticScale.Client/ShardManagement/ShardMapper/ListShardMapper.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMapper/ListShardMapper.cs
@@ -36,11 +36,33 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <returns>An opened SqlConnection.</returns>
         public SqlConnection OpenConnectionForKey(TKey key, string connectionString, ConnectionOptions options = ConnectionOptions.Validate)
         {
+            return this.OpenConnectionForKey(
+                key,
+                connectionString,
+                null,
+                options);
+        }
+
+        /// <summary>
+        /// Given a key value, obtains a SqlConnection to the shard in the mapping
+        /// that contains the key value.
+        /// </summary>
+        /// <param name="key">Input key value.</param>
+        /// <param name="connectionString">
+        /// Connection string with credential information, the DataSource and Database are 
+        /// obtained from the results of the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure Sql Credential.</param>
+        /// <param name="options">Options for validation operations to perform on opened connection.</param>
+        /// <returns>An opened SqlConnection.</returns>
+        public SqlConnection OpenConnectionForKey(TKey key, string connectionString, SqlCredential secureCredential, ConnectionOptions options = ConnectionOptions.Validate)
+        {
             return this.OpenConnectionForKey<PointMapping<TKey>, TKey>(
                 key,
                 (smm, sm, ssm) => new PointMapping<TKey>(smm, sm, ssm),
                 ShardManagementErrorCategory.ListShardMap,
                 connectionString,
+                secureCredential,
                 options);
         }
 
@@ -58,11 +80,34 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <remarks>All non usage-error exceptions will be reported via the returned Task</remarks>
         public Task<SqlConnection> OpenConnectionForKeyAsync(TKey key, string connectionString, ConnectionOptions options = ConnectionOptions.Validate)
         {
+            return this.OpenConnectionForKeyAsync(
+                key,
+                connectionString,
+                null,
+                options);
+        }
+
+        /// <summary>
+        /// Given a key value, asynchronously obtains a SqlConnection to the shard in the mapping
+        /// that contains the key value.
+        /// </summary>
+        /// <param name="key">Input key value.</param>
+        /// <param name="connectionString">
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        /// Connection string with credential information, the DataSource and Database are 
+        /// obtained from the results of the lookup operation for key.
+        /// </param>
+        /// <param name="options">Options for validation operations to perform on opened connection.</param>
+        /// <returns>A Task encapsulating an opened SqlConnection.</returns>
+        /// <remarks>All non usage-error exceptions will be reported via the returned Task</remarks>
+        public Task<SqlConnection> OpenConnectionForKeyAsync(TKey key, string connectionString, SqlCredential secureCredential, ConnectionOptions options = ConnectionOptions.Validate)
+        {
             return this.OpenConnectionForKeyAsync<PointMapping<TKey>, TKey>(
                 key,
                 (smm, sm, ssm) => new PointMapping<TKey>(smm, sm, ssm),
                 ShardManagementErrorCategory.ListShardMap,
                 connectionString,
+                secureCredential,
                 options);
         }
 

--- a/Src/ElasticScale.Client/ShardManagement/ShardMapper/RangeShardMapper.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMapper/RangeShardMapper.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -41,11 +40,37 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             string connectionString,
             ConnectionOptions options = ConnectionOptions.Validate)
         {
+            return this.OpenConnectionForKey(
+                key,
+                connectionString,
+                null,
+                options);
+        }
+
+        /// <summary>
+        /// Given a key value, obtains a SqlConnection to the shard in the mapping
+        /// that contains the key value.
+        /// </summary>
+        /// <param name="key">Input key value.</param>
+        /// <param name="connectionString">
+        /// Connection string with credential information, the DataSource and Database are 
+        /// obtained from the results of the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        /// <param name="options">Options for validation operations to perform on opened connection.</param>
+        /// <returns>An opened SqlConnection.</returns>
+        public SqlConnection OpenConnectionForKey(
+            TKey key,
+            string connectionString,
+            SqlCredential secureCredential,
+            ConnectionOptions options = ConnectionOptions.Validate)
+        {
             return this.OpenConnectionForKey<RangeMapping<TKey>, TKey>(
                 key,
                 (smm, sm, ssm) => new RangeMapping<TKey>(smm, sm, ssm),
                 ShardManagementErrorCategory.RangeShardMap,
                 connectionString,
+                secureCredential,
                 options);
         }
 
@@ -65,12 +90,38 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             string connectionString,
             ConnectionOptions options = ConnectionOptions.Validate)
         {
-            return await this.OpenConnectionForKeyAsync<RangeMapping<TKey>, TKey>(
+            return await this.OpenConnectionForKeyAsync(
                 key,
-                (smm, sm, ssm) => new RangeMapping<TKey>(smm, sm, ssm),
-                ShardManagementErrorCategory.RangeShardMap,
                 connectionString,
+                null,
                 options).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Given a key value, asynchronously obtains a SqlConnection to the shard in the mapping
+        /// that contains the key value.
+        /// </summary>
+        /// <param name="key">Input key value.</param>
+        /// <param name="connectionString">
+        /// Connection string with credential information, the DataSource and Database are 
+        /// obtained from the results of the lookup operation for key.
+        /// </param>
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        /// <param name="options">Options for validation operations to perform on opened connection.</param>
+        /// <returns>A Task encapsulating an opened SqlConnection.</returns>
+        public async Task<SqlConnection> OpenConnectionForKeyAsync(
+            TKey key,
+            string connectionString,
+            SqlCredential secureCredential,
+            ConnectionOptions options = ConnectionOptions.Validate)
+        {
+            return await this.OpenConnectionForKeyAsync<RangeMapping<TKey>, TKey>(
+                       key,
+                       (smm, sm, ssm) => new RangeMapping<TKey>(smm, sm, ssm),
+                       ShardManagementErrorCategory.RangeShardMap,
+                       connectionString,
+                       secureCredential,
+                       options).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlStoreConnection.cs
+++ b/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlStoreConnection.cs
@@ -19,15 +19,35 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         private SqlConnection _conn;
 
         /// <summary>
-        /// Constructs an instance of Sql Store Connection.
+        /// Initializes a new instance of the <see cref="SqlStoreConnection"/> class. 
         /// </summary>
-        /// <param name="kind">Type of store connection.</param>
-        /// <param name="connectionString"></param>
-        protected internal SqlStoreConnection(StoreConnectionKind kind, string connectionString)
+        /// <param name="kind">
+        /// Type of store connection.
+        /// </param>
+        /// <param name="connectionString">
+        /// The SQL connection string
+        /// </param>
+        protected internal SqlStoreConnection(StoreConnectionKind kind, string connectionString) 
+            : this(kind, connectionString, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqlStoreConnection"/> class. 
+        /// </summary>
+        /// <param name="kind">
+        /// Type of store connection.
+        /// </param>
+        /// <param name="connectionString">
+        /// The SQL connection string
+        /// </param>
+        /// <param name="secureCredential">
+        /// The secure SQL Credential.
+        /// </param>
+        protected internal SqlStoreConnection(StoreConnectionKind kind, string connectionString, SqlCredential secureCredential)
         {
             this.Kind = kind;
-            _conn = new SqlConnection();
-            _conn.ConnectionString = connectionString;
+            this._conn = new SqlConnection { ConnectionString = connectionString, Credential = secureCredential };
         }
 
         /// <summary>

--- a/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlStoreConnectionFactory.cs
+++ b/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlStoreConnectionFactory.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-
 namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 {
+    using System.Data.SqlClient;
+
     /// <summary>
     /// Constructs instance of Sql Store Connection.
     /// </summary>
@@ -23,9 +23,26 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <param name="kind">Type of store connection.</param>
         /// <param name="connectionString">Connection string for store.</param>
         /// <returns>An unopened instance of the store connection.</returns>
-        public virtual IStoreConnection GetConnection(StoreConnectionKind kind, string connectionString)
+        public virtual IStoreConnection GetConnection(
+            StoreConnectionKind kind,
+            string connectionString)
         {
-            return new SqlStoreConnection(kind, connectionString);
+            return this.GetConnection(kind, connectionString, null);
+        }
+
+        /// <summary>
+        /// Constructs a new instance of store connection.
+        /// </summary>
+        /// <param name="kind">Type of store connection.</param>
+        /// <param name="connectionString">Connection string for store.</param>
+        /// <param name="secureCredential">Secure Credential for store.</param>
+        /// <returns>An unopened instance of the store connection.</returns>
+        public virtual IStoreConnection GetConnection(
+            StoreConnectionKind kind,
+            string connectionString,
+            SqlCredential secureCredential)
+        {
+            return new SqlStoreConnection(kind, connectionString, secureCredential);
         }
 
         /// <summary>
@@ -35,7 +52,18 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <returns>An unopened instance of the user connection.</returns>
         public virtual IUserStoreConnection GetUserConnection(string connectionString)
         {
-            return new SqlUserStoreConnection(connectionString);
+            return this.GetUserConnection(connectionString, null);
+        }
+
+        /// <summary>
+        /// Constructs a new instance of user connection.
+        /// </summary>
+        /// <param name="connectionString">Connection string of user.</param>
+        /// <param name="secureCredential">Secure Credential of user</param>
+        /// <returns>An unopened instance of the user connection.</returns>
+        public virtual IUserStoreConnection GetUserConnection(string connectionString, SqlCredential secureCredential)
+        {
+            return new SqlUserStoreConnection(connectionString, secureCredential);
         }
     }
 }

--- a/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlUserStoreConnection.cs
+++ b/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlUserStoreConnection.cs
@@ -21,9 +21,10 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// Creates a new instance of user store connection.
         /// </summary>
         /// <param name="connectionString">Connection string.</param>
-        internal SqlUserStoreConnection(string connectionString)
+        /// <param name="secureCredential">Secure SQL Credential.</param>
+        internal SqlUserStoreConnection(string connectionString, SqlCredential secureCredential)
         {
-            _conn = new SqlConnection(connectionString);
+            _conn = new SqlConnection { ConnectionString = connectionString, Credential = secureCredential };
         }
 
         /// <summary>

--- a/Src/ElasticScale.Client/ShardManagement/Store/IStoreConnectionFactory.cs
+++ b/Src/ElasticScale.Client/ShardManagement/Store/IStoreConnectionFactory.cs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 {
+    using System.Data.SqlClient;
+
     /// <summary>
     /// Factory for store connections.
     /// </summary>
@@ -13,14 +15,39 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// </summary>
         /// <param name="kind">Type of store connection.</param>
         /// <param name="connectionString">Connection string for store.</param>
+        /// <param name="secureCredential">Secure credential for store.</param>
         /// <returns>An unopened instance of the store connection.</returns>
-        IStoreConnection GetConnection(StoreConnectionKind kind, string connectionString);
+        IStoreConnection GetConnection(
+            StoreConnectionKind kind,
+            string connectionString,
+            SqlCredential secureCredential);
+
+        /// <summary>
+        /// Constructs a new instance of store connection.
+        /// </summary>
+        /// <param name="kind">Type of store connection.</param>
+        /// <param name="connectionString">Connection string for store.</param>
+        /// <returns>An unopened instance of the store connection.</returns>
+        IStoreConnection GetConnection(
+            StoreConnectionKind kind,
+            string connectionString);
+
+        /// <summary>
+        /// Constructs a new instance of user connection.
+        /// </summary>
+        /// <param name="connectionString">Connection string of user.</param>
+        /// <param name="secureCredential">Secure credential of user.</param>
+        /// <returns>An unopened instance of the user connection.</returns>
+        IUserStoreConnection GetUserConnection(
+            string connectionString, 
+            SqlCredential secureCredential);
 
         /// <summary>
         /// Constructs a new instance of user connection.
         /// </summary>
         /// <param name="connectionString">Connection string of user.</param>
         /// <returns>An unopened instance of the user connection.</returns>
-        IUserStoreConnection GetUserConnection(string connectionString);
+        IUserStoreConnection GetUserConnection(
+            string connectionString);
     }
 }

--- a/Src/ElasticScale.Client/ShardManagement/StoreOperations/Base/StoreOperation.cs
+++ b/Src/ElasticScale.Client/ShardManagement/StoreOperations/Base/StoreOperation.cs
@@ -561,12 +561,21 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         }
 
         /// <summary>
+        /// Obtains the Secure Credential for an LSM location.
+        /// </summary>
+        /// <returns>Connection string for LSM given its location.</returns>
+        protected SqlCredential GetSecureCredentialForShardLocation(ShardLocation location)
+        {
+            return this.Manager.Credentials.SecureCredentialShardMapManager;
+        }
+
+        /// <summary>
         /// Given a state of the Do operation progress, gets the corresponding starting point
         /// for Undo operations.
         /// </summary>
         /// <param name="doState">State at which Do operation was executing.</param>
         /// <returns>Corresponding state for Undo operation.</returns>
-        private static StoreOperationState UndoStateForDoState(StoreOperationState doState)
+            private static StoreOperationState UndoStateForDoState(StoreOperationState doState)
         {
             switch (doState)
             {
@@ -644,7 +653,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             // Open global & local connections and acquire application level locks for the corresponding scope.
             _globalConnection = this.Manager.StoreConnectionFactory.GetConnection(
                 StoreConnectionKind.Global,
-                this.Manager.Credentials.ConnectionStringShardMapManager);
+                this.Manager.Credentials.ConnectionStringShardMapManager,
+                this.Manager.Credentials.SecureCredentialShardMapManager);
 
             _globalConnection.OpenWithLock(this.Id);
 
@@ -654,7 +664,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
                 _localConnectionSource = this.Manager.StoreConnectionFactory.GetConnection(
                     StoreConnectionKind.LocalSource,
-                    this.GetConnectionStringForShardLocation(sci.SourceLocation));
+                    this.GetConnectionStringForShardLocation(sci.SourceLocation),
+                    this.GetSecureCredentialForShardLocation(sci.SourceLocation));
 
                 _localConnectionSource.OpenWithLock(this.Id);
             }
@@ -667,7 +678,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 
                 _localConnectionTarget = this.Manager.StoreConnectionFactory.GetConnection(
                     StoreConnectionKind.LocalTarget,
-                    this.GetConnectionStringForShardLocation(sci.TargetLocation));
+                    this.GetConnectionStringForShardLocation(sci.TargetLocation),
+                    this.GetSecureCredentialForShardLocation(sci.TargetLocation));
 
                 _localConnectionTarget.OpenWithLock(this.Id);
             }

--- a/Src/ElasticScale.Client/ShardManagement/StoreOperations/Base/StoreOperationGlobal.cs
+++ b/Src/ElasticScale.Client/ShardManagement/StoreOperations/Base/StoreOperationGlobal.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         internal StoreOperationGlobal(SqlShardMapManagerCredentials credentials, TransientFaultHandling.RetryPolicy retryPolicy, string operationName)
         {
             this.OperationName = operationName;
+
             _credentials = credentials;
             _retryPolicy = retryPolicy;
         }
@@ -313,7 +314,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// </summary>
         private void EstablishConnnection()
         {
-            _globalConnection = new SqlStoreConnection(StoreConnectionKind.Global, _credentials.ConnectionStringShardMapManager);
+            _globalConnection = new SqlStoreConnection(StoreConnectionKind.Global, _credentials.ConnectionStringShardMapManager, _credentials.SecureCredentialShardMapManager);
             _globalConnection.Open();
         }
 
@@ -323,7 +324,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <returns>Task to await connection establishment</returns>
         private Task EstablishConnnectionAsync()
         {
-            _globalConnection = new SqlStoreConnection(StoreConnectionKind.Global, _credentials.ConnectionStringShardMapManager);
+            _globalConnection = new SqlStoreConnection(StoreConnectionKind.Global, _credentials.ConnectionStringShardMapManager, _credentials.SecureCredentialShardMapManager);
             return _globalConnection.OpenAsync();
         }
 

--- a/Src/ElasticScale.Client/ShardManagement/StoreOperations/Base/StoreOperationLocal.cs
+++ b/Src/ElasticScale.Client/ShardManagement/StoreOperations/Base/StoreOperationLocal.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                     InitialCatalog = this.Location.Database
                 };
 
-            _localConnection = new SqlStoreConnection(StoreConnectionKind.LocalSource, localConnectionString.ConnectionString);
+            _localConnection = new SqlStoreConnection(StoreConnectionKind.LocalSource, localConnectionString.ConnectionString, _credentials.SecureCredentialShardMapManager);
             _localConnection.Open();
         }
 

--- a/Src/ElasticScale.Client/ShardManagement/StoreOperations/ShardMapper/UpdateMappingOperation.cs
+++ b/Src/ElasticScale.Client/ShardManagement/StoreOperations/ShardMapper/UpdateMappingOperation.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Data.SqlClient;
 using System.Diagnostics;
-using System.Linq;
 
 namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
 {
@@ -580,10 +579,14 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             SqlUtils.WithSqlExceptionHandling(() =>
             {
                 string sourceShardConnectionString = this.GetConnectionStringForShardLocation(_mappingSource.StoreShard.Location);
+                SqlCredential sourceShardSecureCredential = this.GetSecureCredentialForShardLocation(_mappingSource.StoreShard.Location);
 
                 IStoreResults result;
 
-                using (IStoreConnection connectionForKill = this.Manager.StoreConnectionFactory.GetConnection(StoreConnectionKind.LocalSource, sourceShardConnectionString))
+                using (IStoreConnection connectionForKill = this.Manager.StoreConnectionFactory.GetConnection(
+                    StoreConnectionKind.LocalSource, 
+                    sourceShardConnectionString, 
+                    sourceShardSecureCredential))
                 {
                     connectionForKill.Open();
 

--- a/Test/ElasticScale.ClientTestCommon/ElasticScale.ClientTestCommon.csproj
+++ b/Test/ElasticScale.ClientTestCommon/ElasticScale.ClientTestCommon.csproj
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ProjectGuid>{13200c7c-8606-47b8-a004-570b56e3a9a8}</ProjectGuid>
+    <ProjectGuid>{13200C7C-8606-47B8-A004-570B56E3A9A8}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Azure.SqlDatabase.ElasticScale.ClientTestCommon</RootNamespace>
@@ -28,6 +28,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Data" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -43,6 +44,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="AssertExtensions.cs" />
+    <Compile Include="SqlAuthenticationLogin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Test/ElasticScale.ClientTestCommon/SqlAuthenticationLogin.cs
+++ b/Test/ElasticScale.ClientTestCommon/SqlAuthenticationLogin.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.SqlDatabase.ElasticScale.ClientTestCommon
+{
+    using System;
+    using System.Data.SqlClient;
+    using System.Diagnostics;
+
+    /// <summary>
+    /// Manage SQL Authentication login for testing.
+    /// </summary>
+    public class SqlAuthenticationLogin
+    {
+        /// <summary>
+        /// A counter to ensure each username is unique (to allow for concurrent unit test execution)
+        /// </summary>
+        private static int usernameUniquifier = 1;
+
+        /// <summary>
+        /// The connection string.
+        /// </summary>
+        private readonly string connectionString;
+
+        /// <summary>
+        /// The s_test user.
+        /// </summary>
+        private readonly string testUser;
+
+        /// <summary>
+        /// The s_test password.
+        /// </summary>
+        private readonly string testPassword;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqlAuthenticationLogin"/> class.
+        /// </summary>
+        /// <param name="connectionString">
+        /// The connection string.
+        /// </param>
+        /// <param name="username">
+        /// The username.
+        /// </param>
+        /// <param name="password">
+        /// The password.
+        /// </param>
+        public SqlAuthenticationLogin(string connectionString, string username, string password)
+        {
+            this.connectionString = connectionString;
+            this.testUser = username + "_" + usernameUniquifier++;
+            this.testPassword = password;
+        }
+
+        /// <summary>
+        /// The uniquified user name (to allow for concurrent unit test execution)
+        /// </summary>
+        public string UniquifiedUserName => testUser;
+
+        /// <summary>
+        /// Create test login
+        /// </summary>
+        /// <returns>
+        /// <see cref="bool"/> to indicate success.
+        /// </returns>
+        public bool Create()
+        {
+            try
+            {
+                using (SqlConnection conn = new SqlConnection(this.connectionString))
+                {
+                    conn.Open();
+                    conn.ChangeDatabase("master");
+                    using (SqlCommand cmd = new SqlCommand())
+                    {
+                        cmd.Connection = conn;
+                        cmd.CommandText = $@"
+if exists (select name from syslogins where name = '{this.testUser}')
+begin
+	drop login {this.testUser}
+end
+create login {this.testUser} with password = '{this.testPassword}'";
+                        cmd.ExecuteNonQuery();
+
+                        cmd.CommandText = $"SP_ADDSRVROLEMEMBER  '{this.testUser}', 'sysadmin'";
+                        cmd.ExecuteNonQuery();
+
+                        return true;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine($"Exception caught in CreateTestLogin(): {e}");
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Drop test login.
+        /// </summary>
+        public void Drop()
+        {
+            try
+            {
+                using (SqlConnection conn = new SqlConnection(this.connectionString))
+                {
+                    conn.Open();
+                    conn.ChangeDatabase("master");
+                    using (SqlCommand cmd = new SqlCommand())
+                    {
+                        cmd.Connection = conn;
+                        cmd.CommandText = $@"
+if exists (select name from syslogins where name = '{this.testUser}')
+begin
+	drop login {this.testUser}
+end";
+                        cmd.ExecuteNonQuery();
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Trace.WriteLine($"Exception caught in DropTestLogin(): {e}");
+            }
+        }
+    }
+}

--- a/Test/ElasticScale.ShardManagement.UnitTests/ElasticScale.ShardManagement.UnitTests.csproj
+++ b/Test/ElasticScale.ShardManagement.UnitTests/ElasticScale.ShardManagement.UnitTests.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Web" />
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>

--- a/Test/ElasticScale.ShardManagement.UnitTests/Globals.cs
+++ b/Test/ElasticScale.ShardManagement.UnitTests/Globals.cs
@@ -1,26 +1,44 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Data.SqlClient;
-using Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement;
+using System.Security;
+using System.Web.Security;
 
 namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
 {
+    using System;
+
     /// <summary>
     /// Class that is container of global constants & methods.
     /// </summary>
     internal static class Globals
     {
         /// <summary>
-        /// Connection string for global shard map manager.
+        /// Connection string base for global shard map manager (auth option will be added)
         /// </summary>
-        private const string ShardMapManagerConnString = @"Data Source=" + Globals.ShardMapManagerTestsDatasourceName + ";Initial Catalog=ShardMapManager;Integrated Security=SSPI;";
+        private const string ShardMapManagerConnStringBase =
+            @"Data Source=" + Globals.ShardMapManagerTestsDatasourceName + ";Initial Catalog=ShardMapManager;";
+
+        /// <summary>
+        /// Connection string for global shard map manager for Integrated Auth
+        /// </summary>
+        private const string ShardMapManagerConnString = ShardMapManagerConnStringBase + "Integrated Security=SSPI;";
+
+        /// <summary>
+        /// Connection string for global shard map manager for Sql Auth
+        /// </summary>
+        private const string ShardMapManagerConnStringForSqlAuth = ShardMapManagerConnStringBase + "Integrated Security=False;";
 
         /// <summary>
         /// Connect string for local shard user.
         /// </summary>
         private const string ShardUserConnString = @"Integrated Security=SSPI;";
+
+        /// <summary>
+        /// Connect string for local shard user.
+        /// </summary>
+        private const string ShardUserConnStringForSqlAuth = @"User={0};Password={1}";
 
         /// <summary>
         /// shardMapManager datasource name for unit tests.
@@ -40,13 +58,13 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
         /// <summary>
         /// Connection string for connecting to test server.
         /// </summary>
-        internal const string ShardMapManagerTestConnectionString = @"Data Source=" + Globals.ShardMapManagerTestsDatasourceName + ";Integrated Security=True;";
+        internal const string ShardMapManagerTestConnectionString = @"Data Source=" + Globals.ShardMapManagerTestsDatasourceName + ";Integrated Security=SSPI;";
 
         /// <summary>
         /// Query to create database.
         /// </summary>
         internal const string CreateDatabaseQuery =
-            @"IF EXISTS (SELECT name FROM sys.databases WHERE name = N'{0}') BEGIN DROP DATABASE [{0}] END CREATE DATABASE [{0}]";
+            @"IF EXISTS (SELECT name FROM sys.databases WHERE name = N'{0}') BEGIN ALTER DATABASE [{0}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [{0}] END CREATE DATABASE [{0}]";
 
         /// <summary>
         /// Query to drop database.
@@ -61,6 +79,16 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
             @"IF OBJECT_ID(N'{0}.{1}', N'U') IS NOT NULL DELETE FROM {0}.{1}";
 
         /// <summary>
+        /// Test user to create for Sql Login tests.
+        /// </summary>
+        internal static string SqlLoginTestUser = "ElasticDatabaseToolsTestUser_" + System.Environment.CurrentManagedThreadId;
+
+        /// <summary>
+        /// Password for test user. (with ' and ; replaced with _ to enable test code to work without T/SQL and connection string escaping)
+        /// </summary>
+        internal static readonly string SqlLoginTestPassword = Membership.GeneratePassword(12, 2).Replace("'", "_").Replace(";", "_");
+
+        /// <summary>
         /// SMM connection string.
         /// </summary>
         internal static string ShardMapManagerConnectionString
@@ -72,14 +100,45 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
         }
 
         /// <summary>
+        /// SMM connection string.
+        /// </summary>
+        internal static string ShardMapManagerConnectionStringForSqlAuth => Globals.ShardMapManagerConnStringForSqlAuth;
+
+        /// <summary>
         /// SMM shard connection string.
         /// </summary>
-        internal static string ShardUserConnectionString
+        internal static string ShardUserConnectionString => Globals.ShardUserConnString;
+
+        /// <summary>
+        /// SMM shard connection string.
+        /// </summary>
+        internal static string ShardUserConnectionStringForSqlAuth(string username) => 
+            string.Format(Globals.ShardUserConnStringForSqlAuth, username, SqlLoginTestPassword);
+
+        /// <summary>
+        /// The shard user credential for sql auth.
+        /// </summary>
+        internal static SqlCredential ShardUserCredentialForSqlAuth(string username) => 
+            new SqlCredential(username, GenerateSecureString(SqlLoginTestPassword));
+
+        /// <summary>
+        /// Generate a secure string
+        /// </summary>
+        /// <returns>
+        /// The <see cref="SecureString"/>.
+        /// </returns>
+        private static SecureString GenerateSecureString(string text)
         {
-            get
+            var secret = new SecureString();
+
+            foreach (var character in text.ToCharArray())
             {
-                return Globals.ShardUserConnString;
+                secret.AppendChar(character);
             }
+
+            secret.MakeReadOnly();
+
+            return secret;
         }
     }
 }

--- a/Test/ElasticScale.ShardManagement.UnitTests/ShardMapManagerFactoryTests.cs
+++ b/Test/ElasticScale.ShardManagement.UnitTests/ShardMapManagerFactoryTests.cs
@@ -8,6 +8,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
 {
+    using ClientTestCommon;
+
     /// <summary>
     /// Tests related to ShardMapManagerFactory class and it's methods.
     /// </summary>
@@ -103,9 +105,85 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
         [TestCategory("ExcludeFromGatedCheckin")]
         public void CreateShardMapManager_Overwrite()
         {
-            ShardMapManagerFactory.CreateSqlShardMapManager(
+            var sqlAuthLogin = new SqlAuthenticationLogin(Globals.ShardMapManagerConnectionString, Globals.SqlLoginTestUser, Globals.SqlLoginTestPassword);
+
+            if (sqlAuthLogin.Create())
+            {
+                ShardMapManagerFactory.CreateSqlShardMapManager(
                 Globals.ShardMapManagerConnectionString,
                 ShardMapManagerCreateMode.ReplaceExisting);
+
+                // Cover all the CreateSqlShardMapManager overloads
+                ShardMapManagerFactory.CreateSqlShardMapManager(
+                    Globals.ShardMapManagerConnectionStringForSqlAuth,
+                    Globals.ShardUserCredentialForSqlAuth(sqlAuthLogin.UniquifiedUserName),
+                    ShardMapManagerCreateMode.ReplaceExisting);
+
+                // This overload should fail with a ShardManagementException, because the manager already exists (but the Auth should work) 
+                try
+                {
+                    ShardMapManagerFactory.CreateSqlShardMapManager(
+                        Globals.ShardMapManagerConnectionStringForSqlAuth,
+                        Globals.ShardUserCredentialForSqlAuth(sqlAuthLogin.UniquifiedUserName));
+                    Assert.Fail("This should have thrown, because the manager already exists");
+                }
+                catch (ShardManagementException)
+                {
+                }
+
+                // This overload should fail with a ShardManagementException, because the manager already exists (but the Auth should work) 
+                try
+                {
+                    ShardMapManagerFactory.CreateSqlShardMapManager(Globals.ShardMapManagerConnectionString);
+                    Assert.Fail("This should have thrown, because the manager already exists");
+                }
+                catch (ShardManagementException)
+                {
+                }
+
+                // This overload should fail with a ShardManagementException, because the manager already exists (but the Auth should work) 
+                try
+                {
+                    ShardMapManagerFactory.CreateSqlShardMapManager(
+                        Globals.ShardMapManagerConnectionString,
+                        RetryBehavior.DefaultRetryBehavior);
+                    Assert.Fail("This should have thrown, because the manager already exists");
+                }
+                catch (ShardManagementException)
+                {
+                }
+
+                ShardMapManagerFactory.CreateSqlShardMapManager(
+                    Globals.ShardMapManagerConnectionString,
+                    ShardMapManagerCreateMode.ReplaceExisting,
+                    RetryBehavior.DefaultRetryBehavior);
+
+                ShardMapManagerFactory.CreateSqlShardMapManager(
+                    Globals.ShardMapManagerConnectionStringForSqlAuth,
+                    Globals.ShardUserCredentialForSqlAuth(sqlAuthLogin.UniquifiedUserName),
+                    ShardMapManagerCreateMode.ReplaceExisting,
+                    RetryBehavior.DefaultRetryBehavior);
+
+                ShardMapManagerFactory.CreateSqlShardMapManager(
+                    Globals.ShardMapManagerConnectionString,
+                    ShardMapManagerCreateMode.ReplaceExisting,
+                    RetryBehavior.DefaultRetryBehavior,
+                    null);
+
+                ShardMapManagerFactory.CreateSqlShardMapManager(
+                    Globals.ShardMapManagerConnectionStringForSqlAuth,
+                    Globals.ShardUserCredentialForSqlAuth(sqlAuthLogin.UniquifiedUserName),
+                    ShardMapManagerCreateMode.ReplaceExisting,
+                    RetryBehavior.DefaultRetryBehavior,
+                    null);
+
+                // Drop test login
+                sqlAuthLogin.Drop();
+            }
+            else
+            {
+                Assert.Inconclusive("Failed to create sql login, test skipped");
+            }
         }
 
         /// <summary>
@@ -151,6 +229,40 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
                     loadPolicy,
                     RetryBehavior.DefaultRetryBehavior);
                 Assert.IsNotNull(smm2);
+
+                var sqlAuthLogin = new SqlAuthenticationLogin(Globals.ShardMapManagerConnectionString, Globals.SqlLoginTestUser, Globals.SqlLoginTestPassword);
+
+                if (sqlAuthLogin.Create())
+                {
+                    // Cover all the GetSqlShardMapManager overloads
+                    ShardMapManager smm3 = ShardMapManagerFactory.GetSqlShardMapManager(
+                    Globals.ShardMapManagerConnectionStringForSqlAuth,
+                    Globals.ShardUserCredentialForSqlAuth(sqlAuthLogin.UniquifiedUserName),
+                    loadPolicy,
+                    RetryBehavior.DefaultRetryBehavior);
+                    Assert.IsNotNull(smm3);
+
+                    ShardMapManager smm4 = ShardMapManagerFactory.GetSqlShardMapManager(
+                        Globals.ShardMapManagerConnectionStringForSqlAuth,
+                        Globals.ShardUserCredentialForSqlAuth(sqlAuthLogin.UniquifiedUserName),
+                        loadPolicy,
+                        RetryBehavior.DefaultRetryBehavior,
+                        null);
+                    Assert.IsNotNull(smm4);
+
+                    ShardMapManager smm5 = ShardMapManagerFactory.GetSqlShardMapManager(
+                        Globals.ShardMapManagerConnectionStringForSqlAuth,
+                        Globals.ShardUserCredentialForSqlAuth(sqlAuthLogin.UniquifiedUserName),
+                        loadPolicy);
+                    Assert.IsNotNull(smm5);
+
+                    // Drop test login
+                    sqlAuthLogin.Drop();
+                }
+                else
+                {
+                    Assert.Inconclusive("Failed to create sql login, test skipped");
+                }
             }
         }
 
@@ -184,6 +296,35 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
                     out smm);
                 Assert.IsTrue(success);
                 Assert.IsNotNull(smm);
+
+                // Cover all the overloads
+                var sqlAuthLogin = new SqlAuthenticationLogin(Globals.ShardMapManagerConnectionString, Globals.SqlLoginTestUser, Globals.SqlLoginTestPassword);
+
+                if (sqlAuthLogin.Create())
+                {
+                    success = ShardMapManagerFactory.TryGetSqlShardMapManager(
+                    Globals.ShardMapManagerConnectionStringForSqlAuth,
+                    Globals.ShardUserCredentialForSqlAuth(sqlAuthLogin.UniquifiedUserName),
+                    loadPolicy,
+                    RetryBehavior.DefaultRetryBehavior,
+                    out smm);
+                    Assert.IsTrue(success);
+                    Assert.IsNotNull(smm);
+
+                    success = ShardMapManagerFactory.TryGetSqlShardMapManager(
+                        Globals.ShardMapManagerConnectionStringForSqlAuth,
+                        Globals.ShardUserCredentialForSqlAuth(sqlAuthLogin.UniquifiedUserName),
+                        loadPolicy,
+                        RetryBehavior.DefaultRetryBehavior,
+                        null,
+                        out smm);
+                    Assert.IsTrue(success);
+                    Assert.IsNotNull(smm);
+                }
+                else
+                {
+                    Assert.Inconclusive("Failed to create sql login, test skipped");
+                }
             }
         }
 

--- a/Test/ElasticScale.ShardManagement.UnitTests/Stubs/StubSqlStoreConnectionFactory.cs
+++ b/Test/ElasticScale.ShardManagement.UnitTests/Stubs/StubSqlStoreConnectionFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Data.SqlClient;
 
 namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests.Stubs
 {
@@ -14,9 +15,10 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests.Stu
     internal class StubSqlStoreConnectionFactory : SqlStoreConnectionFactory
     {
         /// <summary>
-        /// Sets the stub of SqlStoreConnectionFactory.GetConnection(StoreConnectionKind kind, String connectionString)
+        /// Sets the stub of SqlStoreConnectionFactory.GetConnection(StoreConnectionKind kind, String connectionString, SqlCredential secureCredential)
         /// </summary>
-        internal Func<StoreConnectionKind, string, IStoreConnection> GetConnectionStoreConnectionKindString;
+        internal Func<StoreConnectionKind, string, SqlCredential, IStoreConnection> GetConnectionStoreConnectionKindString;
+        
         /// <summary>
         /// Sets the stub of SqlStoreConnectionFactory.GetUserConnection(String connectionString)
         /// </summary>
@@ -65,13 +67,26 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests.Stu
         /// <summary>
         /// Sets the stub of SqlStoreConnectionFactory.GetConnection(StoreConnectionKind kind, String connectionString)
         /// </summary>
-        public override IStoreConnection GetConnection(StoreConnectionKind kind, string connectionString)
+        public override IStoreConnection GetConnection(
+            StoreConnectionKind kind,
+            string connectionString)
         {
-            Func<StoreConnectionKind, string, IStoreConnection> func1 = this.GetConnectionStoreConnectionKindString;
+            return GetConnection(kind, connectionString, null);
+        }
+
+        /// <summary>
+        /// Sets the stub of SqlStoreConnectionFactory.GetConnection(StoreConnectionKind kind, String connectionString, SqlCredential secureCredential)
+        /// </summary>
+        public override IStoreConnection GetConnection(
+            StoreConnectionKind kind,
+            string connectionString,
+            SqlCredential secureCredential)
+        {
+            Func<StoreConnectionKind, string, SqlCredential, IStoreConnection> func1 = this.GetConnectionStoreConnectionKindString;
             if (func1 != null)
-                return func1(kind, connectionString);
+                return func1(kind, connectionString, secureCredential);
             if (this.___callBase)
-                return base.GetConnection(kind, connectionString);
+                return base.GetConnection(kind, connectionString, secureCredential);
             return this.InstanceBehavior.Result<StubSqlStoreConnectionFactory, IStoreConnection>(this, "GetConnection");
         }
 
@@ -80,11 +95,19 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests.Stu
         /// </summary>
         public override IUserStoreConnection GetUserConnection(string connectionString)
         {
+            return this.GetUserConnection(connectionString, null);
+        }
+
+        /// <summary>
+        /// Sets the stub of SqlStoreConnectionFactory.GetUserConnection(String connectionString, SqlCredential secureCredential)
+        /// </summary>
+        public override IUserStoreConnection GetUserConnection(string connectionString, SqlCredential secureCredential)
+        {
             Func<string, IUserStoreConnection> func1 = this.GetUserConnectionString;
             if (func1 != null)
                 return func1(connectionString);
             if (this.___callBase)
-                return base.GetUserConnection(connectionString);
+                return base.GetUserConnection(connectionString, secureCredential);
             return this.InstanceBehavior.Result<StubSqlStoreConnectionFactory, IUserStoreConnection>(this, "GetUserConnection");
         }
 


### PR DESCRIPTION

Add support for the SqlCredential type, as a non-breaking change, in all places where an unencrypted connection string is asked for in the API. 

Unit-tests have been added for all the new overloads.

Fix #170 