### PR TITLE
Ability to specify lookup options

### DIFF
--- a/Src/ElasticScale.Client/Microsoft.Azure.SqlDatabase.ElasticScale.Client.csproj
+++ b/Src/ElasticScale.Client/Microsoft.Azure.SqlDatabase.ElasticScale.Client.csproj
@@ -5,13 +5,11 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Microsoft Azure SQL Database: Elastic Database Client Library</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <PackageTags>Microsoft;Elastic;Scale;Azure;SQL;DB;Database;Shard;Sharding;Management;Query;azureofficial</PackageTags>
-    <PackageReleaseNotes>Added support for .NET Standard 2.0.
-
-Added support for SecureString via SqlCredential.</PackageReleaseNotes>
+    <PackageReleaseNotes>Added support for LookupOptions in ListShardMap.GetMappingForKey(....) , ListShardMap.TryGetMappingForKey(....), RangeShardMap.GetMappingForKey(....), and RangeShardMap.TryGetMappingForKey(....). This gives the ability to lookup from cache instead of only from store, which can greatly improve performance.</PackageReleaseNotes>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageProjectUrl>https://github.com/Azure/elastic-db-tools</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/Azure/elastic-db-tools/blob/master/LICENSE</PackageLicenseUrl>

--- a/Src/ElasticScale.Client/ShardManagement/Shard/LookupOptions.cs
+++ b/Src/ElasticScale.Client/ShardManagement/Shard/LookupOptions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
+{
+    /// <summary>
+    /// Specifies where mapping lookup operations will search for mappings.
+    /// </summary>
+    [Flags]
+    public enum LookupOptions : int
+    {
+        /// <summary>
+        /// Default invalid kind of lookup options.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Attempt to lookup in the local cache.
+        /// </summary>
+        /// <remarks>
+        /// If LookupInCache and LookupInStore are both specified, the cache will be searched first, then the store.
+        /// </remarks>
+        LookupInCache = 1 << 0,
+
+        /// <summary>
+        /// Attempt to lookup in the global shard map store.
+        /// </summary>
+        /// <remarks>
+        /// If LookupInCache and LookupInStore are both specified, the cache will be searched first, then the store.
+        /// </remarks>
+        LookupInStore = 1 << 2,
+    }
+}

--- a/Src/ElasticScale.Client/ShardManagement/Shard/LookupOptions.cs
+++ b/Src/ElasticScale.Client/ShardManagement/Shard/LookupOptions.cs
@@ -30,6 +30,6 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <remarks>
         /// If LookupInCache and LookupInStore are both specified, the cache will be searched first, then the store.
         /// </remarks>
-        LookupInStore = 1 << 2,
+        LookupInStore = 1 << 1,
     }
 }

--- a/Src/ElasticScale.Client/ShardManagement/ShardMapper/BaseShardMapper.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMapper/BaseShardMapper.cs
@@ -535,20 +535,20 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// <typeparam name="TMapping">Mapping type.</typeparam>
         /// <typeparam name="TKey">Key type.</typeparam>
         /// <param name="key">Input key value.</param>
-        /// <param name="useCache">Whether to use cache for lookups.</param>
+        /// <param name="lookupOptions">Whether to use cache and/or storage for lookups.</param>
         /// <param name="constructMapping">Delegate to construct a mapping object.</param>
         /// <param name="errorCategory">Category under which errors must be thrown.</param>
         /// <returns>Mapping that contains the key value.</returns>
         protected TMapping Lookup<TMapping, TKey>(
             TKey key,
-            bool useCache,
+            LookupOptions lookupOptions,
             Func<ShardMapManager, ShardMap, IStoreMapping, TMapping> constructMapping,
             ShardManagementErrorCategory errorCategory)
             where TMapping : class, IShardProvider
         {
             ShardKey sk = new ShardKey(ShardKey.ShardKeyTypeFromType(typeof(TKey)), key);
 
-            if (useCache)
+            if (lookupOptions.HasFlag(LookupOptions.LookupInCache))
             {
                 ICacheStoreMapping cachedMapping = this.Manager.Cache.LookupMappingByKey(this.ShardMap.StoreShardMap, sk);
 
@@ -558,43 +558,44 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
                 }
             }
 
-            // Cache-miss, find mapping for given key in GSM.
-            TMapping m = null;
-
-            IStoreResults gsmResult;
-
-            Stopwatch stopwatch = Stopwatch.StartNew();
-
-            using (IStoreOperationGlobal op = this.Manager.StoreOperationFactory.CreateFindMappingByKeyGlobalOperation(
-                this.Manager,
-                "Lookup",
-                this.ShardMap.StoreShardMap,
-                sk,
-                CacheStoreMappingUpdatePolicy.OverwriteExisting,
-                errorCategory,
-                true,
-                false))
+            // Cache-miss (or didn't use cache), find mapping for given key in GSM.
+            if (lookupOptions.HasFlag(LookupOptions.LookupInStore))
             {
-                gsmResult = op.Do();
+                IStoreResults gsmResult;
+
+                Stopwatch stopwatch = Stopwatch.StartNew();
+
+                using (IStoreOperationGlobal op = this.Manager.StoreOperationFactory.CreateFindMappingByKeyGlobalOperation(
+                    this.Manager,
+                    "Lookup",
+                    this.ShardMap.StoreShardMap,
+                    sk,
+                    CacheStoreMappingUpdatePolicy.OverwriteExisting,
+                    errorCategory,
+                    true,
+                    false))
+                {
+                    gsmResult = op.Do();
+                }
+
+                stopwatch.Stop();
+
+                Tracer.TraceVerbose(
+                    TraceSourceConstants.ComponentNames.BaseShardMapper,
+                    "Lookup",
+                    "Lookup key from GSM complete; Key type : {0}; Result: {1}; Duration: {2}",
+                    typeof(TKey),
+                    gsmResult.Result,
+                    stopwatch.Elapsed);
+
+                // If we could not locate the mapping, we return null and do nothing here.
+                if (gsmResult.Result != StoreResult.MappingNotFoundForKey)
+                {
+                    return gsmResult.StoreMappings.Select(sm => constructMapping(this.Manager, this.ShardMap, sm)).Single();
+                }
             }
 
-            stopwatch.Stop();
-
-            Tracer.TraceVerbose(
-                TraceSourceConstants.ComponentNames.BaseShardMapper,
-                "Lookup",
-                "Lookup key from GSM complete; Key type : {0}; Result: {1}; Duration: {2}",
-                typeof(TKey),
-                gsmResult.Result,
-                stopwatch.Elapsed);
-
-            // If we could not locate the mapping, we return null and do nothing here.
-            if (gsmResult.Result != StoreResult.MappingNotFoundForKey)
-            {
-                return gsmResult.StoreMappings.Select(sm => constructMapping(this.Manager, this.ShardMap, sm)).Single();
-            }
-
-            return m;
+            return null;
         }
 
         /// <summary>

--- a/Src/ElasticScale.Client/ShardManagement/ShardMapper/DefaultShardMapper.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMapper/DefaultShardMapper.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// </summary>
         /// <param name="key">Input shard.</param>
         /// <param name="connectionString">
-        /// Connection string with credential information, the DataSource and Database are 
+        /// Connection string with credential information, the DataSource and Database are
         /// obtained from the results of the lookup operation.
         /// </param>
         /// <param name="options">Options for validation operations to perform on opened connection.</param>
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// </summary>
         /// <param name="key">Input shard.</param>
         /// <param name="connectionString">
-        /// Connection string with credential information, the DataSource and Database are 
+        /// Connection string with credential information, the DataSource and Database are
         /// obtained from the results of the lookup operation.
         /// </param>
         /// <param name="secureCredential">Secure SQL credential.</param>
@@ -62,7 +62,11 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             Debug.Assert(key != null);
             Debug.Assert(connectionString != null);
 
-            return this.ShardMap.OpenConnection(this.Lookup(key, true), connectionString, secureCredential, options);
+            return this.ShardMap.OpenConnection(
+                this.Lookup(key, LookupOptions.LookupInCache | LookupOptions.LookupInStore),
+                connectionString,
+                secureCredential,
+                options);
         }
 
         /// <summary>
@@ -70,7 +74,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// </summary>
         /// <param name="key">Input shard.</param>
         /// <param name="connectionString">
-        /// Connection string with credential information, the DataSource and Database are 
+        /// Connection string with credential information, the DataSource and Database are
         /// obtained from the results of the lookup operation.
         /// </param>
         /// <param name="options">Options for validation operations to perform on opened connection.</param>
@@ -88,7 +92,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// </summary>
         /// <param name="key">Input shard.</param>
         /// <param name="connectionString">
-        /// Connection string with credential information, the DataSource and Database are 
+        /// Connection string with credential information, the DataSource and Database are
         /// obtained from the results of the lookup operation.
         /// </param>
         /// <param name="secureCredential">Secure SQL credential.</param>
@@ -103,7 +107,11 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             Debug.Assert(key != null);
             Debug.Assert(connectionString != null);
 
-            return await this.ShardMap.OpenConnectionAsync(this.Lookup(key, true), connectionString, secureCredential, options).ConfigureAwait(false);
+            return await this.ShardMap.OpenConnectionAsync(
+                this.Lookup(key, LookupOptions.LookupInCache | LookupOptions.LookupInStore),
+                connectionString,
+                secureCredential,
+                options).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -164,9 +172,9 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// Looks up the given shard in the mapper.
         /// </summary>
         /// <param name="shard">Input shard.</param>
-        /// <param name="useCache">Whether to use cache for lookups.</param>
+        /// <param name="lookupOptions">Whether to search in the cache and/or store.</param>
         /// <returns>Returns the shard after verifying that it is present in mapper.</returns>
-        public Shard Lookup(Shard shard, bool useCache)
+        public Shard Lookup(Shard shard, LookupOptions lookupOptions)
         {
             Debug.Assert(shard != null);
 
@@ -177,10 +185,10 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// Tries to looks up the key value and returns the corresponding mapping.
         /// </summary>
         /// <param name="key">Input shard.</param>
-        /// <param name="useCache">Whether to use cache for lookups.</param>
+        /// <param name="lookupOptions">Whether to search in the cache and/or store.</param>
         /// <param name="shard">Shard that contains the key value.</param>
         /// <returns><c>true</c> if shard is found, <c>false</c> otherwise.</returns>
-        public bool TryLookup(Shard key, bool useCache, out Shard shard)
+        public bool TryLookup(Shard key, LookupOptions lookupOptions, out Shard shard)
         {
             Debug.Assert(key != null);
 

--- a/Src/ElasticScale.Client/ShardManagement/ShardMapper/IShardMapper.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMapper/IShardMapper.cs
@@ -142,17 +142,17 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// Looks up the key value and returns the corresponding mapping.
         /// </summary>
         /// <param name="key">Input key value.</param>
-        /// <param name="useCache">Whether to use cache for lookups.</param>
+        /// <param name="lookupOptions">Whether to search in the cache and/or store.</param>
         /// <returns>Mapping that contains the key value.</returns>
-        TMapping Lookup(TKey key, bool useCache);
+        TMapping Lookup(TKey key, LookupOptions lookupOptions);
 
         /// <summary>
         /// Tries to looks up the key value and returns the corresponding mapping.
         /// </summary>
         /// <param name="key">Input key value.</param>
-        /// <param name="useCache">Whether to use cache for lookups.</param>
+        /// <param name="lookupOptions">Whether to search in the cache and/or store.</param>
         /// <param name="mapping">Mapping that contains the key value.</param>
         /// <returns><c>true</c> if mapping is found, <c>false</c> otherwise.</returns>
-        bool TryLookup(TKey key, bool useCache, out TMapping mapping);
+        bool TryLookup(TKey key, LookupOptions lookupOptions, out TMapping mapping);
     }
 }

--- a/Src/ElasticScale.Client/ShardManagement/ShardMapper/ListShardMapper.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMapper/ListShardMapper.cs
@@ -176,13 +176,13 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// Looks up the key value and returns the corresponding mapping.
         /// </summary>
         /// <param name="key">Input key value.</param>
-        /// <param name="useCache">Whether to use cache for lookups.</param>
+        /// <param name="lookupOptions">Whether to search in the cache and/or store.</param>
         /// <returns>Mapping that contains the key value.</returns>
-        public PointMapping<TKey> Lookup(TKey key, bool useCache)
+        public PointMapping<TKey> Lookup(TKey key, LookupOptions lookupOptions)
         {
             PointMapping<TKey> p = this.Lookup<PointMapping<TKey>, TKey>(
                 key,
-                useCache,
+                lookupOptions,
                 (smm, sm, ssm) => new PointMapping<TKey>(smm, sm, ssm),
                 ShardManagementErrorCategory.ListShardMap);
 
@@ -204,14 +204,14 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// Tries to looks up the key value and returns the corresponding mapping.
         /// </summary>
         /// <param name="key">Input key value.</param>
-        /// <param name="useCache">Whether to use cache for lookups.</param>
+        /// <param name="lookupOptions">Whether to search in the cache and/or store.</param>
         /// <param name="mapping">Mapping that contains the key value.</param>
         /// <returns><c>true</c> if mapping is found, <c>false</c> otherwise.</returns>
-        public bool TryLookup(TKey key, bool useCache, out PointMapping<TKey> mapping)
+        public bool TryLookup(TKey key, LookupOptions lookupOptions, out PointMapping<TKey> mapping)
         {
             PointMapping<TKey> p = this.Lookup<PointMapping<TKey>, TKey>(
                 key,
-                useCache,
+                lookupOptions,
                 (smm, sm, ssm) => new PointMapping<TKey>(smm, sm, ssm),
                 ShardManagementErrorCategory.ListShardMap);
 

--- a/Src/ElasticScale.Client/ShardManagement/ShardMapper/RangeShardMapper.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMapper/RangeShardMapper.cs
@@ -189,13 +189,13 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// Looks up the key value and returns the corresponding mapping.
         /// </summary>
         /// <param name="key">Input key value.</param>
-        /// <param name="useCache">Whether to use cache for lookups.</param>
+        /// <param name="lookupOptions">Whether to search in the cache and/or store.</param>
         /// <returns>Mapping that contains the key value.</returns>
-        public RangeMapping<TKey> Lookup(TKey key, bool useCache)
+        public RangeMapping<TKey> Lookup(TKey key, LookupOptions lookupOptions)
         {
             RangeMapping<TKey> p = this.Lookup<RangeMapping<TKey>, TKey>(
                 key,
-                useCache,
+                lookupOptions,
                 (smm, sm, ssm) => new RangeMapping<TKey>(smm, sm, ssm),
                 ShardManagementErrorCategory.RangeShardMap);
 
@@ -217,14 +217,14 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// Tries to looks up the key value and returns the corresponding mapping.
         /// </summary>
         /// <param name="key">Input key value.</param>
-        /// <param name="useCache">Whether to use cache for lookups.</param>
+        /// <param name="lookupOptions">Whether to search in the cache and/or store.</param>
         /// <param name="mapping">Mapping that contains the key value.</param>
         /// <returns><c>true</c> if mapping is found, <c>false</c> otherwise.</returns>
-        public bool TryLookup(TKey key, bool useCache, out RangeMapping<TKey> mapping)
+        public bool TryLookup(TKey key, LookupOptions lookupOptions, out RangeMapping<TKey> mapping)
         {
             RangeMapping<TKey> p = this.Lookup<RangeMapping<TKey>, TKey>(
                 key,
-                useCache,
+                lookupOptions,
                 (smm, sm, ssm) => new RangeMapping<TKey>(smm, sm, ssm),
                 ShardManagementErrorCategory.RangeShardMap);
 

--- a/Test/ElasticScale.ShardManagement.UnitTests/DateTimeShardMapperTests.cs
+++ b/Test/ElasticScale.ShardManagement.UnitTests/DateTimeShardMapperTests.cs
@@ -382,7 +382,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
 
             lsm.DeleteMapping(mappingToDelete);
 
-            // Verify that the mapping is removed from cache.
+            // Try to get from store. Because the mapping is missing from the store, we will try to
+            // invalidate the cache, but since it is also missing from cache there will be an cache miss.
             bool lookupFailed = false;
             try
             {
@@ -396,7 +397,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
             }
 
             Assert.IsTrue(lookupFailed);
-            Assert.AreEqual(0, countingCache.LookupMappingMissCount);
+            Assert.AreEqual(1, countingCache.LookupMappingMissCount);
         }
 
         /// <summary>

--- a/Test/ElasticScale.ShardManagement.UnitTests/ShardMapperTests.cs
+++ b/Test/ElasticScale.ShardManagement.UnitTests/ShardMapperTests.cs
@@ -529,7 +529,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
 
             lsm.DeleteMapping(mappingToDelete);
 
-            // Verify that the mapping is removed from cache.
+            // Try to get from store. Because the mapping is missing from the store, we will try to
+            // invalidate the cache, but since it is also missing from cache there will be an cache miss.
             bool lookupFailed = false;
             try
             {
@@ -543,7 +544,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
             }
 
             Assert.IsTrue(lookupFailed);
-            Assert.AreEqual(0, countingCache.LookupMappingMissCount);
+            Assert.AreEqual(1, countingCache.LookupMappingMissCount);
         }
 
         /// <summary>
@@ -1331,6 +1332,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
 
             rsm.DeleteMapping(mappingToDelete, mappingLockToken);
 
+            // Try to get from store. Because the mapping is missing from the store, we will try to
+            // invalidate the cache, but since it is also missing from cache there will be an cache miss.
             exception = AssertExtensions.AssertThrows<ShardManagementException>
                 (() => rsm.GetMappingForKey(1));
 
@@ -1338,7 +1341,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
                 exception.ErrorCode == ShardManagementErrorCode.MappingNotFoundForKey &&
                 exception.ErrorCategory == ShardManagementErrorCategory.RangeShardMap);
 
-            Assert.AreEqual(0, countingCache.LookupMappingMissCount);
+            Assert.AreEqual(1, countingCache.LookupMappingMissCount);
         }
 
         /// <summary>

--- a/Test/ElasticScale.ShardManagement.UnitTests/ShardMapperTests.cs
+++ b/Test/ElasticScale.ShardManagement.UnitTests/ShardMapperTests.cs
@@ -11,7 +11,6 @@ using System.Data.SqlClient;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.JScript;
 
 namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
 {
@@ -1052,7 +1051,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
             for (int i = 0; i < keysToTest.Count - 1; i++)
             {
                 // https://github.com/Azure/elastic-db-tools/issues/117
-                // Bug? DateTimeOffsets with the same universal time but different offset are equal as ShardKeys. 
+                // Bug? DateTimeOffsets with the same universal time but different offset are equal as ShardKeys.
                 // According to SQL (and our normalization format), they should be unequal, although according to .NET they should be equal.
                 // We need to skip empty ranges because if we use them in this test then we end up with duplicate mappings
                 if (typeof(T) == typeof(DateTimeOffset) && (DateTimeOffset)(object)keysToTest[i] == (DateTimeOffset)(object)keysToTest[i + 1])
@@ -2004,7 +2003,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
             ArgumentOutOfRangeException exception = AssertExtensions.AssertThrows<ArgumentOutOfRangeException>
                 (() => rsm.SplitMapping(r1, 1, mappingLockToken));
 
-            // Unlock mapping 
+            // Unlock mapping
             rsm.UnlockMapping(r1, mappingLockToken);
         }
 

--- a/Test/ElasticScale.ShardManagement.UnitTests/ShardMapperTests.cs
+++ b/Test/ElasticScale.ShardManagement.UnitTests/ShardMapperTests.cs
@@ -2369,6 +2369,11 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
 
             smme = Assert.ThrowsException<ShardManagementException>(() => lsm2.GetMappingForKey(1));
             Assert.AreEqual(ShardManagementErrorCode.MappingNotFoundForKey, smme.ErrorCode);
+
+            // Lookup again from cache - the mapping should have been removed from the cache
+            smme = Assert.ThrowsException<ShardManagementException>(() =>
+                lsm2.GetMappingForKey(1, LookupOptions.LookupInCache));
+            Assert.AreEqual(ShardManagementErrorCode.MappingNotFoundForKey, smme.ErrorCode);
         }
 
         /// <summary>

--- a/Test/ElasticScale.ShardManagement.UnitTests/TestShardMap.cs
+++ b/Test/ElasticScale.ShardManagement.UnitTests/TestShardMap.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE f
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 
@@ -86,6 +86,44 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
             return Do<IMappingInfoProvider>(
                 lsm => lsm.GetMappingForKey(value, lookupOptions),
                 rsm => rsm.GetMappingForKey(value, lookupOptions));
+        }
+
+        public bool TryGetMappingForKey(TKey value, out IMappingInfoProvider mapping)
+        {
+            if (_lsm != null)
+            {
+                bool ret =  _lsm.TryGetMappingForKey(value, out var x);
+                mapping = x;
+                return ret;
+            }
+
+            if (_rsm != null)
+            {
+                bool ret = _rsm.TryGetMappingForKey(value, out var x);
+                mapping = x;
+                return ret;
+            }
+
+            throw new InvalidOperationException("Both lsm and rsm are null!");
+        }
+
+        public bool TryGetMappingForKey(TKey value, LookupOptions lookupOptions, out IMappingInfoProvider mapping)
+        {
+            if (_lsm != null)
+            {
+                bool ret = _lsm.TryGetMappingForKey(value, lookupOptions, out var x);
+                mapping = x;
+                return ret;
+            }
+
+            if (_rsm != null)
+            {
+                bool ret = _rsm.TryGetMappingForKey(value, lookupOptions, out var x);
+                mapping = x;
+                return ret;
+            }
+
+            throw new InvalidOperationException("Both lsm and rsm are null!");
         }
 
         public IMappingInfoProvider MarkMappingOffline(IMappingInfoProvider mapping)

--- a/Test/ElasticScale.ShardManagement.UnitTests/TestShardMap.cs
+++ b/Test/ElasticScale.ShardManagement.UnitTests/TestShardMap.cs
@@ -81,6 +81,13 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
                 rsm => rsm.GetMappingForKey(value));
         }
 
+        public IMappingInfoProvider GetMappingForKey(TKey value, LookupOptions lookupOptions)
+        {
+            return Do<IMappingInfoProvider>(
+                lsm => lsm.GetMappingForKey(value, lookupOptions),
+                rsm => rsm.GetMappingForKey(value, lookupOptions));
+        }
+
         public IMappingInfoProvider MarkMappingOffline(IMappingInfoProvider mapping)
         {
             return Do<IMappingInfoProvider>(

--- a/Test/ElasticScale.ShardManagement.UnitTests/TestShardMap.cs
+++ b/Test/ElasticScale.ShardManagement.UnitTests/TestShardMap.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE f
+
+using System;
+
+namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
+{
+    /// <summary>
+    /// Wrapper that allows for reusing test logic for either a
+    /// <see cref="ListShardMap{TKey}"/> or <see cref="RangeShardMap{TKey}"/>.
+    /// </summary>
+    /// <typeparam name="TKey"></typeparam>
+    internal class TestShardMap<TKey>
+    {
+        private readonly RangeShardMap<TKey> _rsm;
+
+        private readonly ListShardMap<TKey> _lsm;
+
+        public TestShardMap(ListShardMap<TKey> lsm)
+        {
+            _lsm = lsm;
+        }
+
+        public TestShardMap(RangeShardMap<TKey> rsm)
+        {
+            _rsm = rsm;
+        }
+
+        public ShardMap ShardMap
+        {
+            get { return (ShardMap)_rsm ?? _lsm; }
+        }
+
+        protected TResult Do<TResult>(
+            Func<ListShardMap<TKey>, TResult> lsmFunc,
+            Func<RangeShardMap<TKey>, TResult> rsmFunc)
+        {
+            if (_lsm != null)
+            {
+                return lsmFunc(_lsm);
+            }
+
+            if (_rsm != null)
+            {
+                return rsmFunc(_rsm);
+            }
+
+            throw new InvalidOperationException("Both lsm and rsm are null!");
+        }
+
+        protected void Do<TResult>(
+            Action<ListShardMap<TKey>> lsmFunc,
+            Action<RangeShardMap<TKey>> rsmFunc)
+        {
+            if (_lsm != null)
+            {
+                lsmFunc(_lsm);
+                return;
+            }
+
+            if (_rsm != null)
+            {
+                rsmFunc(_rsm);
+                return;
+            }
+
+            throw new InvalidOperationException("Both lsm and rsm are null!");
+        }
+
+        public IMappingInfoProvider CreateMapping(TKey value, TKey nextValue, Shard shard)
+        {
+            return Do<IMappingInfoProvider>(
+                lsm => lsm.CreatePointMapping(value, shard),
+                rsm => rsm.CreateRangeMapping(new Range<TKey>(value, nextValue), shard));
+        }
+
+        public IMappingInfoProvider GetMappingForKey(TKey value)
+        {
+            return Do<IMappingInfoProvider>(
+                lsm => lsm.GetMappingForKey(value),
+                rsm => rsm.GetMappingForKey(value));
+        }
+
+        public IMappingInfoProvider MarkMappingOffline(IMappingInfoProvider mapping)
+        {
+            return Do<IMappingInfoProvider>(
+                lsm => lsm.MarkMappingOffline((PointMapping<TKey>)mapping),
+                rsm => rsm.MarkMappingOffline((RangeMapping<TKey>)mapping));
+        }
+
+        public void DeleteMapping(IMappingInfoProvider mapping)
+        {
+            Do<IMappingInfoProvider>(
+                lsm => lsm.DeleteMapping((PointMapping<TKey>)mapping),
+                rsm => rsm.DeleteMapping((RangeMapping<TKey>)mapping));
+        }
+    }
+}

--- a/Test/ElasticScale.ShardManagement.UnitTests/TestShardMapVerifier.cs
+++ b/Test/ElasticScale.ShardManagement.UnitTests/TestShardMapVerifier.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
+{
+    internal abstract class TestShardMapVerifier
+    {
+        public abstract IMappingInfoProvider GetMappingForKey<TKey>(TestShardMap<TKey> testShardMap, TKey value);
+        public abstract IMappingInfoProvider GetMappingForKey<TKey>(TestShardMap<TKey> testShardMap, TKey value, LookupOptions lookupOptions);
+        public abstract void GetMappingForKey_NotExists<TKey>(TestShardMap<TKey> testShardMap, TKey value);
+        public abstract void GetMappingForKey_NotExists<TKey>(TestShardMap<TKey> testShardMap, TKey value, LookupOptions lookupOptions);
+
+        protected void VerifyMapping(IMappingInfoProvider mapping)
+        {
+            Assert.IsNotNull(mapping);
+        }
+
+        protected void AssertThrowsShardManagementException(Action a, ShardManagementErrorCode expectedCode)
+        {
+            ShardManagementException smme = Assert.ThrowsException<ShardManagementException>(a);
+            Assert.AreEqual(ShardManagementErrorCode.MappingNotFoundForKey, smme.ErrorCode);
+        }
+    }
+
+    /// <summary>
+    /// Verifies methods on shard map using "regular" (exception-throwing) version of test method.
+    /// </summary>
+    internal class ExceptionBasedTestShardMapVerifier : TestShardMapVerifier
+    {
+        public override IMappingInfoProvider GetMappingForKey<TKey>(TestShardMap<TKey> testShardMap, TKey value)
+        {
+            var mapping = testShardMap.GetMappingForKey(value);
+            VerifyMapping(mapping);
+            return mapping;
+        }
+
+        public override IMappingInfoProvider GetMappingForKey<TKey>(TestShardMap<TKey> testShardMap, TKey value, LookupOptions lookupOptions)
+        {
+            var mapping = testShardMap.GetMappingForKey(value, lookupOptions);
+            VerifyMapping(mapping);
+            return mapping;
+        }
+
+        public override void GetMappingForKey_NotExists<TKey>(TestShardMap<TKey> testShardMap, TKey value)
+        {
+            AssertThrowsShardManagementException(
+                () => testShardMap.GetMappingForKey(value),
+                ShardManagementErrorCode.MappingNotFoundForKey);
+        }
+
+        public override void GetMappingForKey_NotExists<TKey>(TestShardMap<TKey> testShardMap, TKey value, LookupOptions lookupOptions)
+        {
+            AssertThrowsShardManagementException(
+                () => testShardMap.GetMappingForKey(value, lookupOptions),
+                ShardManagementErrorCode.MappingNotFoundForKey);
+        }
+    }
+
+    /// <summary>
+    /// Verifies methods on shard map using "try" version of test method.
+    /// </summary>
+    internal class TryBasedTestShardMapVerifier : TestShardMapVerifier
+    {
+        public override IMappingInfoProvider GetMappingForKey<TKey>(TestShardMap<TKey> testShardMap, TKey value)
+        {
+            bool ret = testShardMap.TryGetMappingForKey(value, out IMappingInfoProvider mapping);
+            Assert.IsTrue(ret);
+            VerifyMapping(mapping);
+            return mapping;
+        }
+
+        public override IMappingInfoProvider GetMappingForKey<TKey>(TestShardMap<TKey> testShardMap, TKey value, LookupOptions lookupOptions)
+        {
+            bool ret = testShardMap.TryGetMappingForKey(value, lookupOptions, out IMappingInfoProvider mapping);
+            Assert.IsTrue(ret);
+            VerifyMapping(mapping);
+            return mapping;
+        }
+
+        public override void GetMappingForKey_NotExists<TKey>(TestShardMap<TKey> testShardMap, TKey value)
+        {
+            bool ret = testShardMap.TryGetMappingForKey(value, out IMappingInfoProvider mapping);
+            Assert.IsFalse(ret);
+            Assert.IsNull(mapping);
+        }
+
+        public override void GetMappingForKey_NotExists<TKey>(TestShardMap<TKey> testShardMap, TKey value, LookupOptions lookupOptions)
+        {
+            bool ret = testShardMap.TryGetMappingForKey(value, lookupOptions, out IMappingInfoProvider mapping);
+            Assert.IsFalse(ret);
+            Assert.IsNull(mapping);
+        }
+    }
+}


### PR DESCRIPTION
Lookup from cache only, only from store (this is original behavior), or from cache and then store,. Also when looking up from store only and mapping is not found, invalidate cache.

Fixes #112