### PR TITLE
Update nugets to latest (due to CVEs)

### DIFF
--- a/Samples/Dapper/ElasticDapper.csproj
+++ b/Samples/Dapper/ElasticDapper.csproj
@@ -8,8 +8,8 @@
     <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.Data.NetCore" Version="6.0.1312" />
     <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.NetCore" Version="6.0.1312" />
     <PackageReference Include="Microsoft.Azure.SqlDatabase.ElasticScale.Client" version="2.3.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-    <PackageReference Include="Dapper" Version="2.0.90" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+    <PackageReference Include="Dapper" Version="2.1.28" />
     <PackageReference Include="DapperExtensions" Version="1.7.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Samples/EFCodeFirst/EntityFrameworkCodeFirst.csproj
+++ b/Samples/EFCodeFirst/EntityFrameworkCodeFirst.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
@@ -8,7 +8,7 @@
     <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.Data.NetCore" Version="6.0.1312" />
     <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.NetCore" Version="6.0.1312" />
     <PackageReference Include="Microsoft.Azure.SqlDatabase.ElasticScale.Client" Version="2.3.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
   </ItemGroup>
   <ItemGroup>

--- a/Samples/EFMultiTenant/EntityFrameworkMultiTenant.csproj
+++ b/Samples/EFMultiTenant/EntityFrameworkMultiTenant.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.Data.NetCore" Version="6.0.1312" />
     <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.NetCore" Version="6.0.1312" />
     <PackageReference Include="Microsoft.Azure.SqlDatabase.ElasticScale.Client" Version="2.3.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
     <PackageReference Include="EntityFramework" Version="6.4.4" />
   </ItemGroup>
   <ItemGroup>

--- a/Samples/ElasticScaleStarterKit/ElasticScaleStarterKit.csproj
+++ b/Samples/ElasticScaleStarterKit/ElasticScaleStarterKit.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.Data.NetCore" Version="6.0.1312" />
     <PackageReference Include="EnterpriseLibrary.TransientFaultHandling.NetCore" Version="6.0.1312" />
     <PackageReference Include="Microsoft.Azure.SqlDatabase.ElasticScale.Client" Version="2.3.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="LICENSE" />

--- a/Src/ElasticScale.Client/Microsoft.Azure.SqlDatabase.ElasticScale.Client.csproj
+++ b/Src/ElasticScale.Client/Microsoft.Azure.SqlDatabase.ElasticScale.Client.csproj
@@ -5,7 +5,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Microsoft Azure SQL Database: Elastic Database Client Library</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <Version>2.4.0</Version>
+    <Version>2.4.1-preview1</Version>
     <Authors>Microsoft</Authors>
     <TargetFrameworks>net6.0</TargetFrameworks>
     <PackageTags>Microsoft;Elastic;Scale;Azure;SQL;DB;Database;Shard;Sharding;Management;Query;azureofficial</PackageTags>

--- a/Src/ElasticScale.Client/Microsoft.Azure.SqlDatabase.ElasticScale.Client.csproj
+++ b/Src/ElasticScale.Client/Microsoft.Azure.SqlDatabase.ElasticScale.Client.csproj
@@ -24,7 +24,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('strongname.props'))" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Test/ElasticScale.ClientTestCommon/Microsoft.Azure.SqlDatabase.ElasticScale.ClientTestCommon.csproj
+++ b/Test/ElasticScale.ClientTestCommon/Microsoft.Azure.SqlDatabase.ElasticScale.ClientTestCommon.csproj
@@ -6,7 +6,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('build.props'))" />
   <Import Project="$([MSBuild]::GetPathOfFileAbove('strongname.props'))" />
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>
 </Project>

--- a/Test/ElasticScale.Query.UnitTests/Microsoft.Azure.SqlDatabase.ElasticScale.Query.UnitTests.csproj
+++ b/Test/ElasticScale.Query.UnitTests/Microsoft.Azure.SqlDatabase.ElasticScale.Query.UnitTests.csproj
@@ -7,10 +7,10 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('build.props'))" />
   <Import Project="$([MSBuild]::GetPathOfFileAbove('strongname.props'))" />
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Src\ElasticScale.Client\Microsoft.Azure.SqlDatabase.ElasticScale.Client.csproj" />

--- a/Test/ElasticScale.Query.UnitTests/MultiShardTestUtils.cs
+++ b/Test/ElasticScale.Query.UnitTests/MultiShardTestUtils.cs
@@ -47,12 +47,12 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.Query.UnitTests
         /// <summary>
         /// Connection string for local shard user.
         /// </summary>
-        internal static string ShardConnectionString = @"Integrated Security=SSPI;";
+        internal static string ShardConnectionString = @"Integrated Security=SSPI;TrustServerCertificate=True;";
 
         /// <summary>
         /// Connection string for global shard map manager operations.
         /// </summary>
-        internal static string ShardMapManagerConnectionString = @"Data Source=localhost;Initial Catalog=ShardMapManager;Integrated Security=SSPI;";
+        internal static string ShardMapManagerConnectionString = @"Data Source=localhost;Initial Catalog=ShardMapManager;Integrated Security=SSPI;TrustServerCertificate=True;";
 
         /// <summary>
         /// Name of the database where the ShardMapManager persists its data.
@@ -214,6 +214,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.Query.UnitTests
             builder.DataSource = s_serverLocation;
             builder.IntegratedSecurity = true;
             builder.InitialCatalog = database;
+            builder.TrustServerCertificate = true;
+
             return builder.ConnectionString;
         }
 

--- a/Test/ElasticScale.ShardManagement.UnitTests/Globals.cs
+++ b/Test/ElasticScale.ShardManagement.UnitTests/Globals.cs
@@ -22,22 +22,22 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
         /// <summary>
         /// Connection string for global shard map manager for Integrated Auth
         /// </summary>
-        private const string ShardMapManagerConnString = ShardMapManagerConnStringBase + "Integrated Security=SSPI;";
+        private const string ShardMapManagerConnString = ShardMapManagerConnStringBase + "Integrated Security=SSPI;TrustServerCertificate=True;";
 
         /// <summary>
         /// Connection string for global shard map manager for Sql Auth
         /// </summary>
-        private const string ShardMapManagerConnStringForSqlAuth = ShardMapManagerConnStringBase + "Integrated Security=False;";
+        private const string ShardMapManagerConnStringForSqlAuth = ShardMapManagerConnStringBase + "Integrated Security=False;TrustServerCertificate=True;";
 
         /// <summary>
         /// Connect string for local shard user.
         /// </summary>
-        private const string ShardUserConnString = @"Integrated Security=SSPI;";
+        private const string ShardUserConnString = @"Integrated Security=SSPI;TrustServerCertificate=True;";
 
         /// <summary>
         /// Connect string for local shard user.
         /// </summary>
-        private const string ShardUserConnStringForSqlAuth = @"User={0};Password={1}";
+        private const string ShardUserConnStringForSqlAuth = @"User={0};Password={1};TrustServerCertificate=True;";
 
         /// <summary>
         /// shardMapManager datasource name for unit tests.
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
         /// <summary>
         /// Connection string for connecting to test server.
         /// </summary>
-        internal const string ShardMapManagerTestConnectionString = @"Data Source=" + Globals.ShardMapManagerTestsDatasourceName + ";Integrated Security=SSPI;";
+        internal const string ShardMapManagerTestConnectionString = @"Data Source=" + Globals.ShardMapManagerTestsDatasourceName + ";Integrated Security=SSPI;TrustServerCertificate=True;";
 
         /// <summary>
         /// Query to create database.
@@ -111,13 +111,13 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
         /// <summary>
         /// SMM shard connection string.
         /// </summary>
-        internal static string ShardUserConnectionStringForSqlAuth(string username) => 
+        internal static string ShardUserConnectionStringForSqlAuth(string username) =>
             string.Format(Globals.ShardUserConnStringForSqlAuth, username, SqlLoginTestPassword);
 
         /// <summary>
         /// The shard user credential for sql auth.
         /// </summary>
-        internal static SqlCredential ShardUserCredentialForSqlAuth(string username) => 
+        internal static SqlCredential ShardUserCredentialForSqlAuth(string username) =>
             new SqlCredential(username, GenerateSecureString(SqlLoginTestPassword));
 
         /// <summary>

--- a/Test/ElasticScale.ShardManagement.UnitTests/Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests.csproj
+++ b/Test/ElasticScale.ShardManagement.UnitTests/Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
@@ -8,9 +8,9 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('strongname.props'))" />
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Src\ElasticScale.Client\Microsoft.Azure.SqlDatabase.ElasticScale.Client.csproj" />

--- a/Test/ElasticScale.ShardManagement.UnitTests/ScenarioTests.cs
+++ b/Test/ElasticScale.ShardManagement.UnitTests/ScenarioTests.cs
@@ -308,14 +308,14 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
                 {
                     // Also verify we can connect to the shard with Sql Auth, and Sql Auth using a secure credential
                     using (shardForConnection.OpenConnectionAsync(
-                        string.Empty,
+                        "TrustServerCertificate=True;",
                         Globals.ShardUserCredentialForSqlAuth(sqlAuthLogin.UniquifiedUserName),
                         ConnectionOptions.None).Result)
                     {
                     }
 
                     using (shardForConnection.OpenConnectionAsync(
-                        string.Empty,
+                        "TrustServerCertificate=True;",
                         Globals.ShardUserCredentialForSqlAuth(sqlAuthLogin.UniquifiedUserName)).Result)
                     {
                     }
@@ -1142,7 +1142,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
                     // Cover the OpenConnectionForKey overloads
                     using (SqlConnection conn = newMultiTenantShardMap.OpenConnectionForKey(
                         20,
-                        string.Empty,
+                        "TrustServerCertificate=True;",
                         Globals.ShardUserCredentialForSqlAuth(sqlAuthLogin.UniquifiedUserName)))
                     {
                     }
@@ -1237,7 +1237,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
                     // Cover the OpenConnectionForKeyAsync overloads
                     using (SqlConnection conn = multiTenantShardMap.OpenConnectionForKeyAsync(
                         20,
-                        string.Empty,
+                        "TrustServerCertificate=True;",
                         Globals.ShardUserCredentialForSqlAuth(sqlAuthLogin.UniquifiedUserName),
                         ConnectionOptions.None).Result)
                     {
@@ -1245,7 +1245,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
 
                     using (SqlConnection conn = multiTenantShardMap.OpenConnectionForKeyAsync(
                         20,
-                        string.Empty,
+                        "TrustServerCertificate=True;",
                         Globals.ShardUserCredentialForSqlAuth(sqlAuthLogin.UniquifiedUserName)).Result)
                     {
                     }

--- a/Test/ElasticScale.ShardManagement.UnitTests/ShardMapTests.cs
+++ b/Test/ElasticScale.ShardManagement.UnitTests/ShardMapTests.cs
@@ -221,12 +221,12 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
                 }
 
                 // Validate that we can connect to the shard using a secure Sql Auth Credential
-                using (sNew.OpenConnection(string.Empty, Globals.ShardUserCredentialForSqlAuth(sqlAuthLogin.UniquifiedUserName)))
+                using (sNew.OpenConnection("TrustServerCertificate=True;", Globals.ShardUserCredentialForSqlAuth(sqlAuthLogin.UniquifiedUserName)))
                 {
                 }
 
                 using (sNew.OpenConnection(
-                    string.Empty,
+                    "TrustServerCertificate=True;",
                     Globals.ShardUserCredentialForSqlAuth(sqlAuthLogin.UniquifiedUserName),
                     ConnectionOptions.Validate))
                 {


### PR DESCRIPTION
This Pr brings in the latest Microsoft.Data.SqlClient, which requires TrustServerCertificate to be set to true if the server certificate cannot be trusted.