### PR TITLE
Add 'Active Directory Default' connection string support

### DIFF
--- a/Src/ElasticScale.Client/ShardManagement/ShardMap/ShardMapUtils.cs
+++ b/Src/ElasticScale.Client/ShardManagement/ShardMap/ShardMapUtils.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
         /// SqlAuthenticationMethod.ActiveDirectoryInteractive.ToString() cannot be used
         /// because it may not be available in the .NET framework version that we are running in
         /// </summary>
+        internal static readonly string ActiveDirectoryDefaultStr = "ActiveDirectoryDefault";
         internal static readonly string ActiveDirectoryInteractiveStr = "ActiveDirectoryInteractive";
         internal static readonly string ActiveDirectoryServicePrincipal = "ActiveDirectoryServicePrincipal";
         internal static readonly string ActiveDirectoryDeviceCodeFlow = "ActiveDirectoryDeviceCodeFlow";

--- a/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlShardMapManagerCredentials.cs
+++ b/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlShardMapManagerCredentials.cs
@@ -161,7 +161,8 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             if (connectionString.ContainsKey(ShardMapUtils.Authentication))
             {
                 string authentication = connectionString[ShardMapUtils.Authentication].ToString();
-                if (authentication.Equals(ShardMapUtils.ActiveDirectoryIntegratedStr, StringComparison.OrdinalIgnoreCase)
+                if ( authentication.Equals(ShardMapUtils.ActiveDirectoryDefaultStr, StringComparison.OrdinalIgnoreCase)
+                    || authentication.Equals(ShardMapUtils.ActiveDirectoryIntegratedStr, StringComparison.OrdinalIgnoreCase)
                     || authentication.Equals(ShardMapUtils.ActiveDirectoryInteractiveStr, StringComparison.OrdinalIgnoreCase)
                     || authentication.Equals(ShardMapUtils.ActiveDirectoryManagedIdentity, StringComparison.OrdinalIgnoreCase)
                     || authentication.Equals(ShardMapUtils.ActiveDirectoryServicePrincipal, StringComparison.OrdinalIgnoreCase)

--- a/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlShardMapManagerCredentials.cs
+++ b/Src/ElasticScale.Client/ShardManagement/SqlStore/SqlShardMapManagerCredentials.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement
             if (connectionString.ContainsKey(ShardMapUtils.Authentication))
             {
                 string authentication = connectionString[ShardMapUtils.Authentication].ToString();
-                if ( authentication.Equals(ShardMapUtils.ActiveDirectoryDefaultStr, StringComparison.OrdinalIgnoreCase)
+                if (authentication.Equals(ShardMapUtils.ActiveDirectoryDefaultStr, StringComparison.OrdinalIgnoreCase)
                     || authentication.Equals(ShardMapUtils.ActiveDirectoryIntegratedStr, StringComparison.OrdinalIgnoreCase)
                     || authentication.Equals(ShardMapUtils.ActiveDirectoryInteractiveStr, StringComparison.OrdinalIgnoreCase)
                     || authentication.Equals(ShardMapUtils.ActiveDirectoryManagedIdentity, StringComparison.OrdinalIgnoreCase)


### PR DESCRIPTION
Support ```Authentication=Active Directory Default``` in the connection string

https://learn.microsoft.com/en-us/sql/connect/ado-net/sql/azure-active-directory-authentication?view=sql-server-ver16#setting-microsoft-entra-authentication

Issue #246 