### PR TITLE
Fix security scan findings in test and sample code

### DIFF
--- a/Samples/PowerShell/ExecuteSampleSplitMerge.ps1
+++ b/Samples/PowerShell/ExecuteSampleSplitMerge.ps1
@@ -16,7 +16,7 @@
 .EXAMPLES
     .\ExecuteSampleSplitMerge.ps1 `
         -UserName 'mysqluser' `
-        -Password 'MySqlPassw0rd' `
+        -Password '<my-sql-pwd-of-choice>' `
         -ShardMapManagerServerName 'abcdefghij.database.windows.net' `
         -ShardKeyType 'Int32' `
         -SplitMergeServiceEndpoint 'https://mysplitmergeservice.cloudapp.net' `
@@ -24,7 +24,7 @@
 
     .\ExecuteSampleSplitMerge.ps1 `
         -UserName 'mysqluser' `
-        -Password 'MySqlPassw0rd' `
+        -Password '<my-sql-pwd-of-choice>' `
         -ShardMapManagerServerName 'abcdefghij.database.windows.net' `
         -ShardKeyType 'Int64' `
         -SplitMergeServiceEndpoint 'https://mysplitmergeservice.cloudapp.net' `
@@ -32,7 +32,7 @@
 
     .\ExecuteSampleSplitMerge.ps1 `
         -UserName 'mysqluser' `
-        -Password 'MySqlPassw0rd' `
+        -Password '<my-sql-pwd-of-choice>' `
         -ShardMapManagerServerName 'abcdefghij.database.windows.net' `
         -ShardKeyType 'Guid' `
         -SplitRangeLow '00000000-0000-0000-0000-000000000000' `
@@ -43,7 +43,7 @@
 
     .\ExecuteSampleSplitMerge.ps1 `
         -UserName 'mysqluser' `
-        -Password 'MySqlPassw0rd' `
+        -Password '<my-sql-pwd-of-choice>' `
         -ShardMapManagerServerName 'abcdefghij.database.windows.net' `
         -ShardKeyType 'Binary' `
         -SplitRangeLow '0x00' `
@@ -54,7 +54,7 @@
 
     .\ExecuteSampleSplitMerge.ps1 `
         -UserName 'mysqluser' `
-        -Password 'MySqlPassw0rd' `
+        -Password '<my-sql-pwd-of-choice>' `
         -ShardMapManagerServerName 'abcdefghij.database.windows.net' `
         -ShardKeyType 'Datetime' `
         -SplitRangeLow '2010-3-21 12:00:00' `

--- a/Samples/PowerShell/GetMappings.ps1
+++ b/Samples/PowerShell/GetMappings.ps1
@@ -16,7 +16,7 @@
 .EXAMPLES
     .\GetMappings.ps1 `
         -UserName 'mysqluser' `
-        -Password 'MySqlPassw0rd' `
+        -Password '<my-sql-pwd-of-choice>' `
         -ShardMapManagerServerName 'abcdefghij.database.windows.net' `
         -ShardMapManagerDatabaseName 'MyShardMapManagerDB'
         -ShardMapName 'CustomerIdShardMap'

--- a/Samples/PowerShell/GetShards.ps1
+++ b/Samples/PowerShell/GetShards.ps1
@@ -15,7 +15,7 @@
 .EXAMPLES
     .\GetShards.ps1 `
         -UserName 'mysqluser' `
-        -Password 'MySqlPassw0rd' `
+        -Password '<my-sql-pwd-of-choice>' `
         -ShardMapManagerServerName 'abcdefghij.database.windows.net' `
         -ShardMapManagerDatabaseName 'MyShardMapManagerDB'
         -ShardMapName 'CustomerIdShardMap'

--- a/Samples/PowerShell/SetupSampleSplitMergeEnvironment.ps1
+++ b/Samples/PowerShell/SetupSampleSplitMergeEnvironment.ps1
@@ -16,19 +16,19 @@
 .EXAMPLES
     .\SetupSampleSplitMergeEnvironment.ps1 `
         -UserName 'mysqluser' `
-        -Password 'MySqlPassw0rd' `
+        -Password '<my-sql-pwd-of-choice>' `
         -ShardMapManagerServerName 'abcdefghij.database.windows.net' `
         -ShardKeyType 'Int32'
 
     .\SetupSampleSplitMergeEnvironment.ps1 `
         -UserName 'mysqluser' `
-        -Password 'MySqlPassw0rd' `
+        -Password '<my-sql-pwd-of-choice>' `
         -ShardMapManagerServerName 'abcdefghij.database.windows.net' `
         -ShardKeyType 'Int64'
 
     .\SetupSampleSplitMergeEnvironment.ps1 `
         -UserName 'mysqluser' `
-        -Password 'MySqlPassw0rd' `
+        -Password '<my-sql-pwd-of-choice>' `
         -ShardMapManagerServerName 'abcdefghij.database.windows.net' `
         -ShardKeyType 'Guid' `
         -SplitRangeLow '00000000-0000-0000-0000-000000000000' `
@@ -37,7 +37,7 @@
 
     .\SetupSampleSplitMergeEnvironment.ps1 `
         -UserName 'mysqluser' `
-        -Password 'MySqlPassw0rd' `
+        -Password '<my-sql-pwd-of-choice>' `
         -ShardMapManagerServerName 'abcdefghij.database.windows.net' `
         -ShardKeyType 'Binary' `
         -SplitRangeLow '0x00' `
@@ -46,7 +46,7 @@
 
     .\SetupSampleSplitMergeEnvironment.ps1 `
         -UserName 'mysqluser' `
-        -Password 'MySqlPassw0rd' `
+        -Password '<my-sql-pwd-of-choice>' `
         -ShardMapManagerServerName 'abcdefghij.database.windows.net' `
         -ShardKeyType 'Datetime' `
         -SplitRangeLow '2010-3-21 12:00:00' `

--- a/Test/ElasticScale.ClientTestCommon/CommonTestUtils.cs
+++ b/Test/ElasticScale.ClientTestCommon/CommonTestUtils.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
+using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 
 namespace Microsoft.Azure.SqlDatabase.ElasticScale.Test.Common
@@ -10,13 +14,73 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.Test.Common
         {
             using (MemoryStream memStream = new MemoryStream())
             {
-                BinaryFormatter formatter = new BinaryFormatter();
+                BinaryFormatter formatter = new BinaryFormatter
+                {
+                    // Restrict deserialization to the exception graph these tests round-trip.
+                    // This satisfies CA2301 and prevents BinaryFormatter from instantiating
+                    // arbitrary (potentially dangerous) types.
+                    Binder = new ExceptionRoundTripBinder(),
+                };
 
                 formatter.Serialize(memStream, originalException);
                 memStream.Seek(0, SeekOrigin.Begin);
 
                 return (T)formatter.Deserialize(memStream);
             }
+        }
+
+        /// <summary>
+        /// A <see cref="SerializationBinder"/> that only permits the types that make up the
+        /// serialized graph of the Elastic Scale exceptions exercised by the tests: the
+        /// Elastic Scale types themselves (exceptions, <c>ShardLocation</c>, error-code enums),
+        /// <see cref="Exception"/>, and lists/collections/arrays of those types. Any other type
+        /// is rejected before it can be instantiated.
+        /// </summary>
+        private sealed class ExceptionRoundTripBinder : SerializationBinder
+        {
+            private const string ElasticScaleNamespacePrefix = "Microsoft.Azure.SqlDatabase.ElasticScale";
+
+            public override Type BindToType(string assemblyName, string typeName)
+            {
+                // Resolving a Type does not instantiate anything; the object is only created
+                // by the formatter after we return an allowed type. Reject disallowed types up front.
+                Type type = Type.GetType(string.Format("{0}, {1}", typeName, assemblyName), throwOnError: false);
+
+                if (type == null || !IsAllowed(type))
+                {
+                    throw new SerializationException(
+                        string.Format("Type '{0}' from assembly '{1}' is not allowed to be deserialized.", typeName, assemblyName));
+                }
+
+                return type;
+            }
+
+            private static bool IsAllowed(Type type)
+            {
+                if (type.IsArray)
+                {
+                    return IsAllowed(type.GetElementType());
+                }
+
+                if (type.IsGenericType)
+                {
+                    Type definition = type.GetGenericTypeDefinition();
+                    if (definition != typeof(List<>) && definition != typeof(ReadOnlyCollection<>))
+                    {
+                        return false;
+                    }
+
+                    return type.GetGenericArguments().All(IsAllowed);
+                }
+
+                return type.IsPrimitive
+                    || type == typeof(string)
+                    || type == typeof(Exception)
+                    || IsElasticScaleType(type);
+            }
+
+            private static bool IsElasticScaleType(Type type) =>
+                type.Namespace != null && type.Namespace.StartsWith(ElasticScaleNamespacePrefix, StringComparison.Ordinal);
         }
     }
 }

--- a/Test/ElasticScale.Query.UnitTests/MultiShardTestUtils.cs
+++ b/Test/ElasticScale.Query.UnitTests/MultiShardTestUtils.cs
@@ -31,11 +31,6 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.Query.UnitTests
         private static string s_testUserId = "TestUser";
 
         /// <summary>
-        /// User password to use when connecting to shards during a fanout query.
-        /// </summary>
-        private static string s_testPassword = "Pwd_" + Guid.NewGuid().ToString("N") + "!aA1";
-
-        /// <summary>
         /// Table name for the sharded table we will issue fanout queries against.
         /// </summary>
         private static string s_testTableName = "ConsistentShardedTable";
@@ -326,7 +321,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.Query.UnitTests
 
             // Then re create it.
             //
-            output.Add(string.Format("CREATE LOGIN {0} WITH Password = '{1}';", s_testUserId, s_testPassword));
+            output.Add(string.Format("CREATE LOGIN {0} WITH Password = '{1}';", s_testUserId, Guid.NewGuid().ToString()));
 
             // Then grant it lots of permissions.
             //

--- a/Test/ElasticScale.Query.UnitTests/MultiShardTestUtils.cs
+++ b/Test/ElasticScale.Query.UnitTests/MultiShardTestUtils.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.Query.UnitTests
         /// <summary>
         /// User password to use when connecting to shards during a fanout query.
         /// </summary>
-        private static string s_testPassword = "J8X2ndQTZ8cvu1r";
+        private static string s_testPassword = "Pwd_" + Guid.NewGuid().ToString("N") + "!aA1";
 
         /// <summary>
         /// Table name for the sharded table we will issue fanout queries against.

--- a/Test/ElasticScale.ShardManagement.UnitTests/Globals.cs
+++ b/Test/ElasticScale.ShardManagement.UnitTests/Globals.cs
@@ -83,9 +83,10 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
         internal static string SqlLoginTestUser = "ElasticDatabaseToolsTestUser_" + System.Environment.CurrentManagedThreadId;
 
         /// <summary>
-        /// Password for test user. (with ' and ; replaced with _ to enable test code to work without T/SQL and connection string escaping)
+        /// Password for test user. Randomly generated per run so no credential is hard-coded in source. A GUID
+        /// contains no quote/semicolon and satisfies SQL Server password complexity (lowercase, digits, hyphens).
         /// </summary>
-        internal static readonly string SqlLoginTestPassword = "Pwd_" + Guid.NewGuid().ToString("N") + "!aA1";
+        internal static readonly string SqlLoginTestPassword = Guid.NewGuid().ToString();
 
         /// <summary>
         /// SMM connection string.

--- a/Test/ElasticScale.ShardManagement.UnitTests/Globals.cs
+++ b/Test/ElasticScale.ShardManagement.UnitTests/Globals.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.SqlDatabase.ElasticScale.ShardManagement.UnitTests
         /// <summary>
         /// Password for test user. (with ' and ; replaced with _ to enable test code to work without T/SQL and connection string escaping)
         /// </summary>
-        internal static readonly string SqlLoginTestPassword = "TestPa$$w0rd" + Guid.NewGuid().ToString("N");
+        internal static readonly string SqlLoginTestPassword = "Pwd_" + Guid.NewGuid().ToString("N") + "!aA1";
 
         /// <summary>
         /// SMM connection string.


### PR DESCRIPTION
Address 7 Azure DevOps security findings across test utilities and
PowerShell samples:

- CommonTestUtils.cs (CA2301): Replace BinaryFormatter.Deserialize
  pragma suppression with a restrictive SerializationBinder
  (ExceptionRoundTripBinder) that only allows primitives, string,
  Exception, List<>/ReadOnlyCollection<>, and ElasticScale types.
- Globals.cs (CSCAN-MSFT0090): Replace hardcoded test login password
  with a runtime-generated value.
- MultiShardTestUtils.cs (CSCAN-GENERAL0060): Replace hardcoded test
  login password with a runtime-generated value.
- PowerShell sample help (CSCAN-MSFT0090): Replace example passwords in
  comment-based help with the <my-sql-pwd-of-choice> placeholder in
  GetMappings.ps1, GetShards.ps1, ExecuteSampleSplitMerge.ps1, and
  SetupSampleSplitMergeEnvironment.ps1.

Validated: exception serialization tests pass on net481, net6.0, and
net8.0.
